### PR TITLE
Add ResNet18 torch-mlir lowering script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ python scripts/resnet18_to_mlir.py \
 
 Use `--emit-debug-info` to include source locations and type aliases in the
 resulting MLIR text.
+
+## Generated MLIR sample
+
+The repository includes a reference MLIR module produced with the default
+settings at `mlir_outputs/resnet18.mlir`. Regenerate it with:
+
+```bash
+python scripts/resnet18_to_mlir.py --output mlir_outputs/resnet18.mlir
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # MLModelMLIRGEN
+
+This repository contains a utility script that demonstrates how to lower a
+ResNet-18 model defined in PyTorch to the MLIR `linalg-on-tensors` dialect using
+[torch-mlir](https://github.com/llvm/torch-mlir).
+
+## Requirements
+
+* Python 3.9+
+* [PyTorch](https://pytorch.org/)
+* [torch-mlir](https://github.com/llvm/torch-mlir)
+
+The script only depends on PyTorch and torch-mlir.  A compact implementation of
+the ResNet-18 architecture is included to avoid additional third-party
+dependencies such as `torchvision`.
+
+## Usage
+
+```bash
+python scripts/resnet18_to_mlir.py --output resnet18.mlir
+```
+
+The command above writes the MLIR module to `resnet18.mlir`.  Omitting the
+`--output` flag prints the generated IR to stdout instead.  Additional options
+control the example input shape and exported symbol name:
+
+```bash
+python scripts/resnet18_to_mlir.py \ 
+  --batch-size 1 \ 
+  --height 224 \ 
+  --width 224 \ 
+  --num-classes 1000 \ 
+  --exported-name forward
+```
+
+Use `--emit-debug-info` to include source locations and type aliases in the
+resulting MLIR text.

--- a/mlir_outputs/resnet18.mlir
+++ b/mlir_outputs/resnet18.mlir
@@ -1,0 +1,562 @@
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+#map4 = affine_map<(d0, d1) -> (d1, d0)>
+#map5 = affine_map<(d0, d1) -> (0, d1)>
+#map6 = affine_map<(d0, d1) -> (d1)>
+module attributes {torch.debug_module_name = "ResNet"} {
+  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
+  func.func @forward(%arg0: tensor<1x3x224x224xf32>) -> tensor<1x1000xf32> {
+    %cst = arith.constant dense_resource<__elided__> : tensor<1000xf32>
+    %cst_0 = arith.constant dense_resource<__elided__> : tensor<1000x512xf32>
+    %cst_1 = arith.constant dense_resource<__elided__> : tensor<512x512x3x3xf32>
+    %cst_2 = arith.constant dense_resource<__elided__> : tensor<512x512x3x3xf32>
+    %cst_3 = arith.constant dense_resource<__elided__> : tensor<512x256x1x1xf32>
+    %cst_4 = arith.constant dense_resource<__elided__> : tensor<512x512x3x3xf32>
+    %cst_5 = arith.constant dense<1.000000e+00> : tensor<512xf32>
+    %cst_6 = arith.constant dense<0.000000e+00> : tensor<512xf32>
+    %cst_7 = arith.constant dense_resource<__elided__> : tensor<512x256x3x3xf32>
+    %cst_8 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_9 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_10 = arith.constant dense_resource<__elided__> : tensor<256x128x1x1xf32>
+    %cst_11 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_12 = arith.constant dense<1.000000e+00> : tensor<256xf32>
+    %cst_13 = arith.constant dense<0.000000e+00> : tensor<256xf32>
+    %cst_14 = arith.constant dense_resource<__elided__> : tensor<256x128x3x3xf32>
+    %cst_15 = arith.constant dense_resource<__elided__> : tensor<128x128x3x3xf32>
+    %cst_16 = arith.constant dense_resource<__elided__> : tensor<128x128x3x3xf32>
+    %cst_17 = arith.constant dense_resource<__elided__> : tensor<128x64x1x1xf32>
+    %cst_18 = arith.constant dense_resource<__elided__> : tensor<128x128x3x3xf32>
+    %cst_19 = arith.constant dense<1.000000e+00> : tensor<128xf32>
+    %cst_20 = arith.constant dense<0.000000e+00> : tensor<128xf32>
+    %cst_21 = arith.constant dense_resource<__elided__> : tensor<128x64x3x3xf32>
+    %cst_22 = arith.constant dense_resource<__elided__> : tensor<64x64x3x3xf32>
+    %cst_23 = arith.constant dense_resource<__elided__> : tensor<64x64x3x3xf32>
+    %cst_24 = arith.constant dense_resource<__elided__> : tensor<64x64x3x3xf32>
+    %cst_25 = arith.constant dense_resource<__elided__> : tensor<64x64x3x3xf32>
+    %cst_26 = arith.constant dense<1.000000e+00> : tensor<64xf32>
+    %cst_27 = arith.constant dense<0.000000e+00> : tensor<64xf32>
+    %cst_28 = arith.constant dense_resource<__elided__> : tensor<64x3x7x7xf32>
+    %false = arith.constant false
+    %cst_29 = arith.constant 0.000000e+00 : f32
+    %cst_30 = arith.constant 0xFF800000 : f32
+    %cst_31 = arith.constant 1.000000e-05 : f64
+    %c0 = arith.constant 0 : index
+    %c3 = arith.constant 3 : index
+    %c1 = arith.constant 1 : index
+    %cst_32 = arith.constant 4.900000e+01 : f32
+    %padded = tensor.pad %arg0 low[0, 0, 3, 3] high[0, 0, 3, 3] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x3x224x224xf32> to tensor<1x3x230x230xf32>
+    %0 = tensor.empty() : tensor<1x64x112x112xf32>
+    %1 = linalg.fill ins(%cst_29 : f32) outs(%0 : tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded, %cst_28 : tensor<1x3x230x230xf32>, tensor<64x3x7x7xf32>) outs(%1 : tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32>
+    %3 = arith.cmpi eq, %false, %false : i1
+    cf.assert %3, "training is not supported for now"
+    %4 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %cst_26, %cst_27, %cst_27, %cst_26 : tensor<1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%2 : tensor<1x64x112x112xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x64x112x112xf32>
+    %5 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4 : tensor<1x64x112x112xf32>) outs(%0 : tensor<1x64x112x112xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x64x112x112xf32>
+    %padded_33 = tensor.pad %5 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_30 : f32
+    } : tensor<1x64x112x112xf32> to tensor<1x64x114x114xf32>
+    %6 = tensor.empty() : tensor<1x64x56x56xf32>
+    %7 = linalg.fill ins(%cst_30 : f32) outs(%6 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %8 = tensor.empty() : tensor<3x3xf32>
+    %9 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_33, %8 : tensor<1x64x114x114xf32>, tensor<3x3xf32>) outs(%7 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %padded_34 = tensor.pad %9 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %10 = linalg.fill ins(%cst_29 : f32) outs(%6 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %11 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_34, %cst_25 : tensor<1x64x58x58xf32>, tensor<64x64x3x3xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %12 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%11, %cst_26, %cst_27, %cst_27, %cst_26 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%11 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x64x56x56xf32>
+    %13 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%12 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x64x56x56xf32>
+    %padded_35 = tensor.pad %13 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %14 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_35, %cst_24 : tensor<1x64x58x58xf32>, tensor<64x64x3x3xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %15 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%14, %cst_26, %cst_27, %cst_27, %cst_26 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%14 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x64x56x56xf32>
+    %16 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%15, %9 : tensor<1x64x56x56xf32>, tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x64x56x56xf32>
+    %17 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%16 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x64x56x56xf32>
+    %padded_36 = tensor.pad %17 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %18 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_36, %cst_23 : tensor<1x64x58x58xf32>, tensor<64x64x3x3xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %19 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%18, %cst_26, %cst_27, %cst_27, %cst_26 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%18 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x64x56x56xf32>
+    %20 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%19 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x64x56x56xf32>
+    %padded_37 = tensor.pad %20 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %21 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_37, %cst_22 : tensor<1x64x58x58xf32>, tensor<64x64x3x3xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %22 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%21, %cst_26, %cst_27, %cst_27, %cst_26 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%21 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x64x56x56xf32>
+    %23 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%22, %17 : tensor<1x64x56x56xf32>, tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x64x56x56xf32>
+    %24 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%23 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x64x56x56xf32>
+    %padded_38 = tensor.pad %24 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %25 = tensor.empty() : tensor<1x128x28x28xf32>
+    %26 = linalg.fill ins(%cst_29 : f32) outs(%25 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    %27 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_38, %cst_21 : tensor<1x64x58x58xf32>, tensor<128x64x3x3xf32>) outs(%26 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %28 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%27, %cst_19, %cst_20, %cst_20, %cst_19 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%27 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x128x28x28xf32>
+    %29 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%28 : tensor<1x128x28x28xf32>) outs(%25 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x128x28x28xf32>
+    %padded_39 = tensor.pad %29 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x128x28x28xf32> to tensor<1x128x30x30xf32>
+    %30 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_39, %cst_18 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%26 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %31 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%30, %cst_19, %cst_20, %cst_20, %cst_19 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%30 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x128x28x28xf32>
+    %32 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%24, %cst_17 : tensor<1x64x56x56xf32>, tensor<128x64x1x1xf32>) outs(%26 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %33 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%32, %cst_19, %cst_20, %cst_20, %cst_19 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%32 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x128x28x28xf32>
+    %34 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%31, %33 : tensor<1x128x28x28xf32>, tensor<1x128x28x28xf32>) outs(%25 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x128x28x28xf32>
+    %35 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%34 : tensor<1x128x28x28xf32>) outs(%25 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x128x28x28xf32>
+    %padded_40 = tensor.pad %35 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x128x28x28xf32> to tensor<1x128x30x30xf32>
+    %36 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_40, %cst_16 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%26 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %37 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %cst_19, %cst_20, %cst_20, %cst_19 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%36 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x128x28x28xf32>
+    %38 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%37 : tensor<1x128x28x28xf32>) outs(%25 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x128x28x28xf32>
+    %padded_41 = tensor.pad %38 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x128x28x28xf32> to tensor<1x128x30x30xf32>
+    %39 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_41, %cst_15 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%26 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %40 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%39, %cst_19, %cst_20, %cst_20, %cst_19 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%39 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x128x28x28xf32>
+    %41 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%40, %35 : tensor<1x128x28x28xf32>, tensor<1x128x28x28xf32>) outs(%25 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x128x28x28xf32>
+    %42 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%41 : tensor<1x128x28x28xf32>) outs(%25 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x128x28x28xf32>
+    %padded_42 = tensor.pad %42 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x128x28x28xf32> to tensor<1x128x30x30xf32>
+    %43 = tensor.empty() : tensor<1x256x14x14xf32>
+    %44 = linalg.fill ins(%cst_29 : f32) outs(%43 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    %45 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_42, %cst_14 : tensor<1x128x30x30xf32>, tensor<256x128x3x3xf32>) outs(%44 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %46 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%45, %cst_12, %cst_13, %cst_13, %cst_12 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%45 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x256x14x14xf32>
+    %47 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%46 : tensor<1x256x14x14xf32>) outs(%43 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_43 = tensor.pad %47 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %48 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_43, %cst_11 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%44 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %49 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%48, %cst_12, %cst_13, %cst_13, %cst_12 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%48 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x256x14x14xf32>
+    %50 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%42, %cst_10 : tensor<1x128x28x28xf32>, tensor<256x128x1x1xf32>) outs(%44 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %51 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%50, %cst_12, %cst_13, %cst_13, %cst_12 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%50 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x256x14x14xf32>
+    %52 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%49, %51 : tensor<1x256x14x14xf32>, tensor<1x256x14x14xf32>) outs(%43 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x256x14x14xf32>
+    %53 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%52 : tensor<1x256x14x14xf32>) outs(%43 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_44 = tensor.pad %53 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %54 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_44, %cst_9 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%44 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %55 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%54, %cst_12, %cst_13, %cst_13, %cst_12 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%54 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x256x14x14xf32>
+    %56 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%55 : tensor<1x256x14x14xf32>) outs(%43 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_45 = tensor.pad %56 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %57 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_45, %cst_8 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%44 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %58 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%57, %cst_12, %cst_13, %cst_13, %cst_12 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%57 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x256x14x14xf32>
+    %59 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%58, %53 : tensor<1x256x14x14xf32>, tensor<1x256x14x14xf32>) outs(%43 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x256x14x14xf32>
+    %60 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%59 : tensor<1x256x14x14xf32>) outs(%43 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_46 = tensor.pad %60 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %61 = tensor.empty() : tensor<1x512x7x7xf32>
+    %62 = linalg.fill ins(%cst_29 : f32) outs(%61 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    %63 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_46, %cst_7 : tensor<1x256x16x16xf32>, tensor<512x256x3x3xf32>) outs(%62 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %64 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%63, %cst_5, %cst_6, %cst_6, %cst_5 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%63 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x512x7x7xf32>
+    %65 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%64 : tensor<1x512x7x7xf32>) outs(%61 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x512x7x7xf32>
+    %padded_47 = tensor.pad %65 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x512x7x7xf32> to tensor<1x512x9x9xf32>
+    %66 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_47, %cst_4 : tensor<1x512x9x9xf32>, tensor<512x512x3x3xf32>) outs(%62 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %67 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%66, %cst_5, %cst_6, %cst_6, %cst_5 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%66 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x512x7x7xf32>
+    %68 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%60, %cst_3 : tensor<1x256x14x14xf32>, tensor<512x256x1x1xf32>) outs(%62 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %69 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%68, %cst_5, %cst_6, %cst_6, %cst_5 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%68 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x512x7x7xf32>
+    %70 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%67, %69 : tensor<1x512x7x7xf32>, tensor<1x512x7x7xf32>) outs(%61 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x512x7x7xf32>
+    %71 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%70 : tensor<1x512x7x7xf32>) outs(%61 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x512x7x7xf32>
+    %padded_48 = tensor.pad %71 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x512x7x7xf32> to tensor<1x512x9x9xf32>
+    %72 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_48, %cst_2 : tensor<1x512x9x9xf32>, tensor<512x512x3x3xf32>) outs(%62 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %73 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%72, %cst_5, %cst_6, %cst_6, %cst_5 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%72 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x512x7x7xf32>
+    %74 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%73 : tensor<1x512x7x7xf32>) outs(%61 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x512x7x7xf32>
+    %padded_49 = tensor.pad %74 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_29 : f32
+    } : tensor<1x512x7x7xf32> to tensor<1x512x9x9xf32>
+    %75 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_49, %cst_1 : tensor<1x512x9x9xf32>, tensor<512x512x3x3xf32>) outs(%62 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %76 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%75, %cst_5, %cst_6, %cst_6, %cst_5 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%75 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %in_51: f32, %in_52: f32, %in_53: f32, %out: f32):
+      %90 = arith.truncf %cst_31 : f64 to f32
+      %91 = arith.addf %in_53, %90 : f32
+      %92 = math.rsqrt %91 : f32
+      %93 = arith.subf %in, %in_52 : f32
+      %94 = arith.mulf %93, %92 : f32
+      %95 = arith.mulf %94, %in_50 : f32
+      %96 = arith.addf %95, %in_51 : f32
+      linalg.yield %96 : f32
+    } -> tensor<1x512x7x7xf32>
+    %77 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%76, %71 : tensor<1x512x7x7xf32>, tensor<1x512x7x7xf32>) outs(%61 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x512x7x7xf32>
+    %78 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%77 : tensor<1x512x7x7xf32>) outs(%61 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.cmpf ugt, %in, %cst_29 : f32
+      %91 = arith.select %90, %in, %cst_29 : f32
+      linalg.yield %91 : f32
+    } -> tensor<1x512x7x7xf32>
+    %79 = tensor.empty() : tensor<1x512x1x1xf32>
+    %80 = linalg.fill ins(%cst_29 : f32) outs(%79 : tensor<1x512x1x1xf32>) -> tensor<1x512x1x1xf32>
+    %81 = tensor.empty() : tensor<7x7xf32>
+    %82 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%78, %81 : tensor<1x512x7x7xf32>, tensor<7x7xf32>) outs(%80 : tensor<1x512x1x1xf32>) -> tensor<1x512x1x1xf32>
+    %83 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%82 : tensor<1x512x1x1xf32>) outs(%79 : tensor<1x512x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %90 = arith.divf %in, %cst_32 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x512x1x1xf32>
+    %collapsed = tensor.collapse_shape %83 [[0], [1, 2, 3]] : tensor<1x512x1x1xf32> into tensor<1x512xf32>
+    %84 = tensor.empty() : tensor<512x1000xf32>
+    %85 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel"]} ins(%cst_0 : tensor<1000x512xf32>) outs(%84 : tensor<512x1000xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<512x1000xf32>
+    %86 = tensor.empty() : tensor<1x1000xf32>
+    %87 = linalg.fill ins(%cst_29 : f32) outs(%86 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %88 = linalg.matmul ins(%collapsed, %85 : tensor<1x512xf32>, tensor<512x1000xf32>) outs(%87 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %89 = linalg.generic {indexing_maps = [#map5, #map6, #map3], iterator_types = ["parallel", "parallel"]} ins(%88, %cst : tensor<1x1000xf32>, tensor<1000xf32>) outs(%86 : tensor<1x1000xf32>) {
+    ^bb0(%in: f32, %in_50: f32, %out: f32):
+      %90 = arith.addf %in, %in_50 : f32
+      linalg.yield %90 : f32
+    } -> tensor<1x1000xf32>
+    return %89 : tensor<1x1000xf32>
+  }
+}

--- a/scripts/resnet18_to_mlir.py
+++ b/scripts/resnet18_to_mlir.py
@@ -1,0 +1,283 @@
+"""Utility to compile a ResNet-18 model to MLIR using torch-mlir.
+
+This script builds a ResNet-18 network in PyTorch and lowers it to the
+``linalg-on-tensors`` dialect with :mod:`torch_mlir`.  It is intended to be a
+minimal, dependency-light example of using torch-mlir for model conversion.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional, Sequence
+
+import torch
+from torch import nn
+
+try:
+    import torch_mlir
+except ImportError as exc:  # pragma: no cover - import guard
+    raise SystemExit(
+        "torch-mlir must be installed to run this script. See "
+        "https://github.com/llvm/torch-mlir for installation instructions."
+    ) from exc
+
+
+# ---------------------------------------------------------------------------
+# ResNet-18 implementation
+# ---------------------------------------------------------------------------
+
+
+def _conv3x3(in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
+    """3x3 convolution with padding."""
+
+    return nn.Conv2d(
+        in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False
+    )
+
+
+def _conv1x1(in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
+    """1x1 convolution."""
+
+    return nn.Conv2d(
+        in_planes, out_planes, kernel_size=1, stride=stride, padding=0, bias=False
+    )
+
+
+class BasicBlock(nn.Module):
+    """Residual building block used by ResNet-18."""
+
+    expansion: int = 1
+
+    def __init__(
+        self,
+        inplanes: int,
+        planes: int,
+        stride: int = 1,
+        downsample: Optional[nn.Module] = None,
+        norm_layer: Optional[nn.Module] = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+
+        self.conv1 = _conv3x3(inplanes, planes, stride)
+        self.bn1 = norm_layer(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = _conv3x3(planes, planes)
+        self.bn2 = norm_layer(planes)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class ResNet(nn.Module):
+    """Minimal ResNet backbone matching the ResNet-18 topology."""
+
+    def __init__(
+        self,
+        block: type[BasicBlock],
+        layers: Sequence[int],
+        num_classes: int = 1000,
+        norm_layer: Optional[nn.Module] = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.conv1 = nn.Conv2d(
+            3, self.inplanes, kernel_size=7, stride=2, padding=3, bias=False
+        )
+        self.bn1 = norm_layer(self.inplanes)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+        self.layer1 = self._make_layer(block, 64, layers[0])
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(512 * block.expansion, num_classes)
+
+        self._initialize_weights()
+
+    def _make_layer(
+        self,
+        block: type[BasicBlock],
+        planes: int,
+        blocks: int,
+        stride: int = 1,
+    ) -> nn.Sequential:
+        norm_layer = self._norm_layer
+        downsample: Optional[nn.Module] = None
+
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                _conv1x1(self.inplanes, planes * block.expansion, stride),
+                norm_layer(planes * block.expansion),
+            )
+
+        layers: list[nn.Module] = []
+        layers.append(block(self.inplanes, planes, stride, downsample, norm_layer))
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(block(self.inplanes, planes, norm_layer=norm_layer))
+
+        return nn.Sequential(*layers)
+
+    def _initialize_weights(self) -> None:
+        for module in self.modules():
+            if isinstance(module, nn.Conv2d):
+                nn.init.kaiming_normal_(module.weight, mode="fan_out", nonlinearity="relu")
+            elif isinstance(module, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(module.weight, 1.0)
+                nn.init.constant_(module.bias, 0.0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        x = self.avgpool(x)
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+        return x
+
+
+def resnet18(num_classes: int = 1000) -> ResNet:
+    """Constructs a ResNet-18 model instance."""
+
+    return ResNet(BasicBlock, layers=(2, 2, 2, 2), num_classes=num_classes)
+
+
+# ---------------------------------------------------------------------------
+# MLIR generation logic
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1,
+        help="Batch dimension size for the example input tensor (default: 1).",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=224,
+        help="Input tensor height in pixels (default: 224).",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=224,
+        help="Input tensor width in pixels (default: 224).",
+    )
+    parser.add_argument(
+        "--num-classes",
+        type=int,
+        default=1000,
+        help="Number of output classes for the classification head (default: 1000).",
+    )
+    parser.add_argument(
+        "--exported-name",
+        type=str,
+        default="forward",
+        help="Name of the exported function in the resulting MLIR module.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write the MLIR module. If omitted the module is printed to stdout.",
+    )
+    parser.add_argument(
+        "--emit-debug-info",
+        action="store_true",
+        help="Emit debug information (locations, type aliases) in the MLIR output.",
+    )
+    return parser.parse_args(argv)
+
+
+def build_example_inputs(batch: int, height: int, width: int) -> Sequence[torch.Tensor]:
+    example = torch.randn(batch, 3, height, width, dtype=torch.float32)
+    return (example,)
+
+
+def compile_to_linalg_on_tensors(
+    module: torch.nn.Module,
+    example_inputs: Sequence[torch.Tensor],
+    exported_name: str,
+    emit_debug_info: bool,
+) -> str:
+    scripted_module = torch.jit.script(module)
+
+    compiled = torch_mlir.compile(
+        scripted_module,
+        example_inputs,
+        output_type=torch_mlir.OutputType.LINALG_ON_TENSORS,
+        exported_name=exported_name,
+    )
+
+    return compiled.operation.get_asm(
+        large_elements_limit=10,
+        enable_debug_info=emit_debug_info,
+        print_generic_op_form=False,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+
+    model = resnet18(num_classes=args.num_classes)
+    model.eval()
+
+    example_inputs = build_example_inputs(args.batch_size, args.height, args.width)
+
+    mlir_text = compile_to_linalg_on_tensors(
+        model,
+        example_inputs,
+        exported_name=args.exported_name,
+        emit_debug_info=args.emit_debug_info,
+    )
+
+    if args.output is None:
+        print(mlir_text)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(mlir_text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a ResNet-18 PyTorch implementation and CLI that lowers to the torch-mlir linalg-on-tensors dialect
- document the script requirements and usage in the README

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68cd1ec3fbd48325a386a94def415684