### PR TITLE
Add pre-generated MLIR exports for multiple torchvision models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,77 @@
 # MLModelMLIRGEN
 
-This repository contains a utility script that demonstrates how to lower a
-ResNet-18 model defined in PyTorch to the MLIR `linalg-on-tensors` dialect using
+This repository contains a utility script that demonstrates how to lower
+classification models from
+[torchvision](https://pytorch.org/vision/stable/index.html) to the MLIR
+`linalg-on-tensors` dialect using
 [torch-mlir](https://github.com/llvm/torch-mlir).
 
 ## Requirements
 
 * Python 3.9+
 * [PyTorch](https://pytorch.org/)
+* [torchvision](https://pytorch.org/vision/stable/index.html)
 * [torch-mlir](https://github.com/llvm/torch-mlir)
 
-The script only depends on PyTorch and torch-mlir.  A compact implementation of
-the ResNet-18 architecture is included to avoid additional third-party
-dependencies such as `torchvision`.
+Install the dependencies with your preferred package manager, for example:
+
+```bash
+pip install torch torchvision torch-mlir
+```
 
 ## Usage
 
+The script defaults to `resnet18`, but any torchvision architecture can be
+selected with `--model` and, optionally, pretrained weights via `--weights`.
+
 ```bash
+# Generate MLIR for the default ResNet-18 model
 python scripts/resnet18_to_mlir.py --output resnet18.mlir
+
+# Export MobileNetV3 with ImageNet weights
+python scripts/resnet18_to_mlir.py \
+  --model mobilenet_v3_small \
+  --weights IMAGENET1K_V1 \
+  --output mobilenet_v3_small.mlir
+
+# Instantiate EfficientNet-B0 with a custom classifier head
+python scripts/resnet18_to_mlir.py \
+  --model efficientnet_b0 \
+  --num-classes 5 \
+  --output efficientnet_b0_5cls.mlir
 ```
 
-The command above writes the MLIR module to `resnet18.mlir`.  Omitting the
-`--output` flag prints the generated IR to stdout instead.  Additional options
-control the example input shape and exported symbol name:
+Use the input-shape flags to match your data layout when the defaults (batch =
+1, channels = 3, height = 224, width = 224) are not appropriate:
 
 ```bash
-python scripts/resnet18_to_mlir.py \ 
-  --batch-size 1 \ 
-  --height 224 \ 
-  --width 224 \ 
-  --num-classes 1000 \ 
-  --exported-name forward
+python scripts/resnet18_to_mlir.py \
+  --model convnext_tiny \
+  --batch-size 8 \
+  --channels 6 \
+  --height 128 \
+  --width 128
 ```
 
-Use `--emit-debug-info` to include source locations and type aliases in the
-resulting MLIR text.
+Set `--exported-name` to control the symbol emitted in the MLIR module and
+`--emit-debug-info` to include source locations and type aliases in the
+generated text. Omitting `--output` prints the MLIR to stdout instead of writing
+to disk.
 
-## Generated MLIR sample
+## Generated MLIR samples
 
-The repository includes a reference MLIR module produced with the default
-settings at `mlir_outputs/resnet18.mlir`. Regenerate it with:
+The repository includes several pre-generated MLIR modules under
+`mlir_outputs/` to make it easy to inspect the lowering for different
+architectures:
 
-```bash
-python scripts/resnet18_to_mlir.py --output mlir_outputs/resnet18.mlir
-```
+| File | Command used to regenerate |
+| ---- | -------------------------- |
+| `resnet18.mlir` | `python scripts/resnet18_to_mlir.py --output mlir_outputs/resnet18.mlir` |
+| `resnet50.mlir` | `python scripts/resnet18_to_mlir.py --model resnet50 --output mlir_outputs/resnet50.mlir` |
+| `mobilenet_v3_small_imagenet.mlir` | `python scripts/resnet18_to_mlir.py --model mobilenet_v3_small --weights IMAGENET1K_V1 --output mlir_outputs/mobilenet_v3_small_imagenet.mlir` |
+| `alexnet.mlir` | `python scripts/resnet18_to_mlir.py --model alexnet --output mlir_outputs/alexnet.mlir` |
+| `squeezenet1_1.mlir` | `python scripts/resnet18_to_mlir.py --model squeezenet1_1 --output mlir_outputs/squeezenet1_1.mlir` |
+
+These examples demonstrate how the script handles different classifier head
+layouts and optional pretrained weights. Re-run any command above to refresh the
+corresponding MLIR file.

--- a/mlir_outputs/alexnet.mlir
+++ b/mlir_outputs/alexnet.mlir
@@ -1,0 +1,176 @@
+#map = affine_map<(d0, d1, d2, d3) -> (d1)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+#map4 = affine_map<(d0, d1) -> (d1, d0)>
+#map5 = affine_map<(d0, d1) -> (0, d1)>
+#map6 = affine_map<(d0, d1) -> (d1)>
+module attributes {torch.debug_module_name = "AlexNet"} {
+  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
+  func.func @forward(%arg0: tensor<1x3x224x224xf32>) -> tensor<1x1000xf32> {
+    %cst = arith.constant dense_resource<__elided__> : tensor<1000xf32>
+    %cst_0 = arith.constant dense_resource<__elided__> : tensor<1000x4096xf32>
+    %cst_1 = arith.constant dense_resource<__elided__> : tensor<4096xf32>
+    %cst_2 = arith.constant dense_resource<__elided__> : tensor<4096x4096xf32>
+    %cst_3 = arith.constant dense_resource<__elided__> : tensor<4096xf32>
+    %cst_4 = arith.constant dense_resource<__elided__> : tensor<4096x9216xf32>
+    %cst_5 = arith.constant dense_resource<__elided__> : tensor<256xf32>
+    %cst_6 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_7 = arith.constant dense_resource<__elided__> : tensor<256xf32>
+    %cst_8 = arith.constant dense_resource<__elided__> : tensor<256x384x3x3xf32>
+    %cst_9 = arith.constant dense_resource<__elided__> : tensor<384xf32>
+    %cst_10 = arith.constant dense_resource<__elided__> : tensor<384x192x3x3xf32>
+    %cst_11 = arith.constant dense_resource<__elided__> : tensor<192xf32>
+    %cst_12 = arith.constant dense_resource<__elided__> : tensor<192x64x5x5xf32>
+    %cst_13 = arith.constant dense_resource<__elided__> : tensor<64xf32>
+    %cst_14 = arith.constant dense_resource<__elided__> : tensor<64x3x11x11xf32>
+    %cst_15 = arith.constant 0.000000e+00 : f32
+    %cst_16 = arith.constant 0xFF800000 : f32
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %padded = tensor.pad %arg0 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_15 : f32
+    } : tensor<1x3x224x224xf32> to tensor<1x3x228x228xf32>
+    %0 = tensor.empty() : tensor<1x64x55x55xf32>
+    %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_13 : tensor<64xf32>) outs(%0 : tensor<1x64x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x64x55x55xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<4> : vector<2xi64>} ins(%padded, %cst_14 : tensor<1x3x228x228xf32>, tensor<64x3x11x11xf32>) outs(%1 : tensor<1x64x55x55xf32>) -> tensor<1x64x55x55xf32>
+    %3 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<1x64x55x55xf32>) outs(%0 : tensor<1x64x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %50 = arith.cmpf ugt, %in, %cst_15 : f32
+      %51 = arith.select %50, %in, %cst_15 : f32
+      linalg.yield %51 : f32
+    } -> tensor<1x64x55x55xf32>
+    %4 = tensor.empty() : tensor<1x64x27x27xf32>
+    %5 = linalg.fill ins(%cst_16 : f32) outs(%4 : tensor<1x64x27x27xf32>) -> tensor<1x64x27x27xf32>
+    %6 = tensor.empty() : tensor<3x3xf32>
+    %7 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%3, %6 : tensor<1x64x55x55xf32>, tensor<3x3xf32>) outs(%5 : tensor<1x64x27x27xf32>) -> tensor<1x64x27x27xf32>
+    %padded_17 = tensor.pad %7 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_15 : f32
+    } : tensor<1x64x27x27xf32> to tensor<1x64x31x31xf32>
+    %8 = tensor.empty() : tensor<1x192x27x27xf32>
+    %9 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_11 : tensor<192xf32>) outs(%8 : tensor<1x192x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x192x27x27xf32>
+    %10 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_17, %cst_12 : tensor<1x64x31x31xf32>, tensor<192x64x5x5xf32>) outs(%9 : tensor<1x192x27x27xf32>) -> tensor<1x192x27x27xf32>
+    %11 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10 : tensor<1x192x27x27xf32>) outs(%8 : tensor<1x192x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %50 = arith.cmpf ugt, %in, %cst_15 : f32
+      %51 = arith.select %50, %in, %cst_15 : f32
+      linalg.yield %51 : f32
+    } -> tensor<1x192x27x27xf32>
+    %12 = tensor.empty() : tensor<1x192x13x13xf32>
+    %13 = linalg.fill ins(%cst_16 : f32) outs(%12 : tensor<1x192x13x13xf32>) -> tensor<1x192x13x13xf32>
+    %14 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%11, %6 : tensor<1x192x27x27xf32>, tensor<3x3xf32>) outs(%13 : tensor<1x192x13x13xf32>) -> tensor<1x192x13x13xf32>
+    %padded_18 = tensor.pad %14 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_15 : f32
+    } : tensor<1x192x13x13xf32> to tensor<1x192x15x15xf32>
+    %15 = tensor.empty() : tensor<1x384x13x13xf32>
+    %16 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_9 : tensor<384xf32>) outs(%15 : tensor<1x384x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x384x13x13xf32>
+    %17 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_18, %cst_10 : tensor<1x192x15x15xf32>, tensor<384x192x3x3xf32>) outs(%16 : tensor<1x384x13x13xf32>) -> tensor<1x384x13x13xf32>
+    %18 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%17 : tensor<1x384x13x13xf32>) outs(%15 : tensor<1x384x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %50 = arith.cmpf ugt, %in, %cst_15 : f32
+      %51 = arith.select %50, %in, %cst_15 : f32
+      linalg.yield %51 : f32
+    } -> tensor<1x384x13x13xf32>
+    %padded_19 = tensor.pad %18 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_15 : f32
+    } : tensor<1x384x13x13xf32> to tensor<1x384x15x15xf32>
+    %19 = tensor.empty() : tensor<1x256x13x13xf32>
+    %20 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_7 : tensor<256xf32>) outs(%19 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x256x13x13xf32>
+    %21 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_19, %cst_8 : tensor<1x384x15x15xf32>, tensor<256x384x3x3xf32>) outs(%20 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %22 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%21 : tensor<1x256x13x13xf32>) outs(%19 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %50 = arith.cmpf ugt, %in, %cst_15 : f32
+      %51 = arith.select %50, %in, %cst_15 : f32
+      linalg.yield %51 : f32
+    } -> tensor<1x256x13x13xf32>
+    %padded_20 = tensor.pad %22 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_15 : f32
+    } : tensor<1x256x13x13xf32> to tensor<1x256x15x15xf32>
+    %23 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_5 : tensor<256xf32>) outs(%19 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x256x13x13xf32>
+    %24 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_20, %cst_6 : tensor<1x256x15x15xf32>, tensor<256x256x3x3xf32>) outs(%23 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %25 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%24 : tensor<1x256x13x13xf32>) outs(%19 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %50 = arith.cmpf ugt, %in, %cst_15 : f32
+      %51 = arith.select %50, %in, %cst_15 : f32
+      linalg.yield %51 : f32
+    } -> tensor<1x256x13x13xf32>
+    %26 = tensor.empty() : tensor<1x256x6x6xf32>
+    %27 = linalg.fill ins(%cst_16 : f32) outs(%26 : tensor<1x256x6x6xf32>) -> tensor<1x256x6x6xf32>
+    %28 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%25, %6 : tensor<1x256x13x13xf32>, tensor<3x3xf32>) outs(%27 : tensor<1x256x6x6xf32>) -> tensor<1x256x6x6xf32>
+    %29 = linalg.fill ins(%cst_15 : f32) outs(%26 : tensor<1x256x6x6xf32>) -> tensor<1x256x6x6xf32>
+    %30 = tensor.empty() : tensor<1x1xf32>
+    %31 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%28, %30 : tensor<1x256x6x6xf32>, tensor<1x1xf32>) outs(%29 : tensor<1x256x6x6xf32>) -> tensor<1x256x6x6xf32>
+    %collapsed = tensor.collapse_shape %31 [[0], [1, 2, 3]] : tensor<1x256x6x6xf32> into tensor<1x9216xf32>
+    %32 = tensor.empty() : tensor<9216x4096xf32>
+    %33 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel"]} ins(%cst_4 : tensor<4096x9216xf32>) outs(%32 : tensor<9216x4096xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<9216x4096xf32>
+    %34 = tensor.empty() : tensor<1x4096xf32>
+    %35 = linalg.fill ins(%cst_15 : f32) outs(%34 : tensor<1x4096xf32>) -> tensor<1x4096xf32>
+    %36 = linalg.matmul ins(%collapsed, %33 : tensor<1x9216xf32>, tensor<9216x4096xf32>) outs(%35 : tensor<1x4096xf32>) -> tensor<1x4096xf32>
+    %37 = linalg.generic {indexing_maps = [#map5, #map6, #map3], iterator_types = ["parallel", "parallel"]} ins(%36, %cst_3 : tensor<1x4096xf32>, tensor<4096xf32>) outs(%34 : tensor<1x4096xf32>) {
+    ^bb0(%in: f32, %in_21: f32, %out: f32):
+      %50 = arith.addf %in, %in_21 : f32
+      linalg.yield %50 : f32
+    } -> tensor<1x4096xf32>
+    %38 = linalg.generic {indexing_maps = [#map5, #map3], iterator_types = ["parallel", "parallel"]} ins(%37 : tensor<1x4096xf32>) outs(%34 : tensor<1x4096xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %50 = arith.cmpf ugt, %in, %cst_15 : f32
+      %51 = arith.select %50, %in, %cst_15 : f32
+      linalg.yield %51 : f32
+    } -> tensor<1x4096xf32>
+    %39 = tensor.empty() : tensor<4096x4096xf32>
+    %40 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel"]} ins(%cst_2 : tensor<4096x4096xf32>) outs(%39 : tensor<4096x4096xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<4096x4096xf32>
+    %41 = linalg.matmul ins(%38, %40 : tensor<1x4096xf32>, tensor<4096x4096xf32>) outs(%35 : tensor<1x4096xf32>) -> tensor<1x4096xf32>
+    %42 = linalg.generic {indexing_maps = [#map5, #map6, #map3], iterator_types = ["parallel", "parallel"]} ins(%41, %cst_1 : tensor<1x4096xf32>, tensor<4096xf32>) outs(%34 : tensor<1x4096xf32>) {
+    ^bb0(%in: f32, %in_21: f32, %out: f32):
+      %50 = arith.addf %in, %in_21 : f32
+      linalg.yield %50 : f32
+    } -> tensor<1x4096xf32>
+    %43 = linalg.generic {indexing_maps = [#map5, #map3], iterator_types = ["parallel", "parallel"]} ins(%42 : tensor<1x4096xf32>) outs(%34 : tensor<1x4096xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %50 = arith.cmpf ugt, %in, %cst_15 : f32
+      %51 = arith.select %50, %in, %cst_15 : f32
+      linalg.yield %51 : f32
+    } -> tensor<1x4096xf32>
+    %44 = tensor.empty() : tensor<4096x1000xf32>
+    %45 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel"]} ins(%cst_0 : tensor<1000x4096xf32>) outs(%44 : tensor<4096x1000xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<4096x1000xf32>
+    %46 = tensor.empty() : tensor<1x1000xf32>
+    %47 = linalg.fill ins(%cst_15 : f32) outs(%46 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %48 = linalg.matmul ins(%43, %45 : tensor<1x4096xf32>, tensor<4096x1000xf32>) outs(%47 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %49 = linalg.generic {indexing_maps = [#map5, #map6, #map3], iterator_types = ["parallel", "parallel"]} ins(%48, %cst : tensor<1x1000xf32>, tensor<1000xf32>) outs(%46 : tensor<1x1000xf32>) {
+    ^bb0(%in: f32, %in_21: f32, %out: f32):
+      %50 = arith.addf %in, %in_21 : f32
+      linalg.yield %50 : f32
+    } -> tensor<1x1000xf32>
+    return %49 : tensor<1x1000xf32>
+  }
+}

--- a/mlir_outputs/mobilenet_v3_small_imagenet.mlir
+++ b/mlir_outputs/mobilenet_v3_small_imagenet.mlir
@@ -1,0 +1,1867 @@
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>
+#map3 = affine_map<() -> ()>
+#map4 = affine_map<(d0, d1, d2, d3) -> ()>
+#map5 = affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0, d1) -> (0, d1)>
+#map9 = affine_map<(d0, d1) -> (d1)>
+#map10 = affine_map<(d0, d1) -> ()>
+module attributes {torch.debug_module_name = "MobileNetV3"} {
+  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
+  func.func @forward(%arg0: tensor<1x3x224x224xf32>) -> tensor<1x1000xf32> {
+    %cst = arith.constant dense_resource<__elided__> : tensor<1000xf32>
+    %cst_0 = arith.constant dense_resource<__elided__> : tensor<1000x1024xf32>
+    %cst_1 = arith.constant dense_resource<__elided__> : tensor<1024xf32>
+    %cst_2 = arith.constant dense_resource<__elided__> : tensor<1024x576xf32>
+    %cst_3 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_4 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_5 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_6 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_7 = arith.constant dense_resource<__elided__> : tensor<576x96x1x1xf32>
+    %cst_8 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_9 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_10 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_11 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_12 = arith.constant dense_resource<__elided__> : tensor<96x576x1x1xf32>
+    %cst_13 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_14 = arith.constant dense_resource<__elided__> : tensor<576x144x1x1xf32>
+    %cst_15 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_16 = arith.constant dense_resource<__elided__> : tensor<144x576x1x1xf32>
+    %cst_17 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_18 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_19 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_20 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_21 = arith.constant dense_resource<__elided__> : tensor<576x1x5x5xf32>
+    %cst_22 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_23 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_24 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_25 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_26 = arith.constant dense_resource<__elided__> : tensor<576x96x1x1xf32>
+    %cst_27 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_28 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_29 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_30 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_31 = arith.constant dense_resource<__elided__> : tensor<96x576x1x1xf32>
+    %cst_32 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_33 = arith.constant dense_resource<__elided__> : tensor<576x144x1x1xf32>
+    %cst_34 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_35 = arith.constant dense_resource<__elided__> : tensor<144x576x1x1xf32>
+    %cst_36 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_37 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_38 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_39 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_40 = arith.constant dense_resource<__elided__> : tensor<576x1x5x5xf32>
+    %cst_41 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_42 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_43 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_44 = arith.constant dense_resource<__elided__> : tensor<576xf32>
+    %cst_45 = arith.constant dense_resource<__elided__> : tensor<576x96x1x1xf32>
+    %cst_46 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_47 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_48 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_49 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_50 = arith.constant dense_resource<__elided__> : tensor<96x288x1x1xf32>
+    %cst_51 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_52 = arith.constant dense_resource<__elided__> : tensor<288x72x1x1xf32>
+    %cst_53 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_54 = arith.constant dense_resource<__elided__> : tensor<72x288x1x1xf32>
+    %cst_55 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_56 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_57 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_58 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_59 = arith.constant dense_resource<__elided__> : tensor<288x1x5x5xf32>
+    %cst_60 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_61 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_62 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_63 = arith.constant dense_resource<__elided__> : tensor<288xf32>
+    %cst_64 = arith.constant dense_resource<__elided__> : tensor<288x48x1x1xf32>
+    %cst_65 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_66 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_67 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_68 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_69 = arith.constant dense_resource<__elided__> : tensor<48x144x1x1xf32>
+    %cst_70 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_71 = arith.constant dense_resource<__elided__> : tensor<144x40x1x1xf32>
+    %cst_72 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_73 = arith.constant dense_resource<__elided__> : tensor<40x144x1x1xf32>
+    %cst_74 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_75 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_76 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_77 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_78 = arith.constant dense_resource<__elided__> : tensor<144x1x5x5xf32>
+    %cst_79 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_80 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_81 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_82 = arith.constant dense_resource<__elided__> : tensor<144xf32>
+    %cst_83 = arith.constant dense_resource<__elided__> : tensor<144x48x1x1xf32>
+    %cst_84 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_85 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_86 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_87 = arith.constant dense_resource<__elided__> : tensor<48xf32>
+    %cst_88 = arith.constant dense_resource<__elided__> : tensor<48x120x1x1xf32>
+    %cst_89 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_90 = arith.constant dense_resource<__elided__> : tensor<120x32x1x1xf32>
+    %cst_91 = arith.constant dense_resource<__elided__> : tensor<32xf32>
+    %cst_92 = arith.constant dense_resource<__elided__> : tensor<32x120x1x1xf32>
+    %cst_93 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_94 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_95 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_96 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_97 = arith.constant dense_resource<__elided__> : tensor<120x1x5x5xf32>
+    %cst_98 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_99 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_100 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_101 = arith.constant dense_resource<__elided__> : tensor<120xf32>
+    %cst_102 = arith.constant dense_resource<__elided__> : tensor<120x40x1x1xf32>
+    %cst_103 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_104 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_105 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_106 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_107 = arith.constant dense_resource<__elided__> : tensor<40x240x1x1xf32>
+    %cst_108 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_109 = arith.constant dense_resource<__elided__> : tensor<240x64x1x1xf32>
+    %cst_110 = arith.constant dense_resource<__elided__> : tensor<64xf32>
+    %cst_111 = arith.constant dense_resource<__elided__> : tensor<64x240x1x1xf32>
+    %cst_112 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_113 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_114 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_115 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_116 = arith.constant dense_resource<__elided__> : tensor<240x1x5x5xf32>
+    %cst_117 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_118 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_119 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_120 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_121 = arith.constant dense_resource<__elided__> : tensor<240x40x1x1xf32>
+    %cst_122 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_123 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_124 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_125 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_126 = arith.constant dense_resource<__elided__> : tensor<40x240x1x1xf32>
+    %cst_127 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_128 = arith.constant dense_resource<__elided__> : tensor<240x64x1x1xf32>
+    %cst_129 = arith.constant dense_resource<__elided__> : tensor<64xf32>
+    %cst_130 = arith.constant dense_resource<__elided__> : tensor<64x240x1x1xf32>
+    %cst_131 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_132 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_133 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_134 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_135 = arith.constant dense_resource<__elided__> : tensor<240x1x5x5xf32>
+    %cst_136 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_137 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_138 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_139 = arith.constant dense_resource<__elided__> : tensor<240xf32>
+    %cst_140 = arith.constant dense_resource<__elided__> : tensor<240x40x1x1xf32>
+    %cst_141 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_142 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_143 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_144 = arith.constant dense_resource<__elided__> : tensor<40xf32>
+    %cst_145 = arith.constant dense_resource<__elided__> : tensor<40x96x1x1xf32>
+    %cst_146 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_147 = arith.constant dense_resource<__elided__> : tensor<96x24x1x1xf32>
+    %cst_148 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_149 = arith.constant dense_resource<__elided__> : tensor<24x96x1x1xf32>
+    %cst_150 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_151 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_152 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_153 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_154 = arith.constant dense_resource<__elided__> : tensor<96x1x5x5xf32>
+    %cst_155 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_156 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_157 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_158 = arith.constant dense_resource<__elided__> : tensor<96xf32>
+    %cst_159 = arith.constant dense_resource<__elided__> : tensor<96x24x1x1xf32>
+    %cst_160 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_161 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_162 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_163 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_164 = arith.constant dense_resource<__elided__> : tensor<24x88x1x1xf32>
+    %cst_165 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_166 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_167 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_168 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_169 = arith.constant dense_resource<__elided__> : tensor<88x1x3x3xf32>
+    %cst_170 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_171 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_172 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_173 = arith.constant dense_resource<__elided__> : tensor<88xf32>
+    %cst_174 = arith.constant dense_resource<__elided__> : tensor<88x24x1x1xf32>
+    %cst_175 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_176 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_177 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_178 = arith.constant dense_resource<__elided__> : tensor<24xf32>
+    %cst_179 = arith.constant dense_resource<__elided__> : tensor<24x72x1x1xf32>
+    %cst_180 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_181 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_182 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_183 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_184 = arith.constant dense_resource<__elided__> : tensor<72x1x3x3xf32>
+    %cst_185 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_186 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_187 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_188 = arith.constant dense_resource<__elided__> : tensor<72xf32>
+    %cst_189 = arith.constant dense_resource<__elided__> : tensor<72x16x1x1xf32>
+    %cst_190 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_191 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_192 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_193 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_194 = arith.constant dense_resource<__elided__> : tensor<16x16x1x1xf32>
+    %cst_195 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_196 = arith.constant dense_resource<__elided__> : tensor<16x8x1x1xf32>
+    %cst_197 = arith.constant dense<[-1.71944425E-9, -2.31662978E-9, -1.6355385E-4, -1.8774664E-9, -1.28914135E-9, 1.75321322E-8, -5.65709568E-9, 9.67229976E-11]> : tensor<8xf32>
+    %cst_198 = arith.constant dense_resource<__elided__> : tensor<8x16x1x1xf32>
+    %cst_199 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_200 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_201 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_202 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_203 = arith.constant dense_resource<__elided__> : tensor<16x1x3x3xf32>
+    %cst_204 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_205 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_206 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_207 = arith.constant dense_resource<__elided__> : tensor<16xf32>
+    %cst_208 = arith.constant dense_resource<__elided__> : tensor<16x3x3x3xf32>
+    %false = arith.constant false
+    %cst_209 = arith.constant 0.000000e+00 : f32
+    %c6_i64 = arith.constant 6 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %cst_210 = arith.constant 1.000000e-03 : f64
+    %c1_i64 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cst_211 = arith.constant 3.000000e+00 : f32
+    %cst_212 = arith.constant 6.000000e+00 : f32
+    %cst_213 = arith.constant 3.136000e+03 : f32
+    %c2 = arith.constant 2 : index
+    %cst_214 = arith.constant 1.960000e+02 : f32
+    %cst_215 = arith.constant 4.900000e+01 : f32
+    %padded = tensor.pad %arg0 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x3x224x224xf32> to tensor<1x3x226x226xf32>
+    %0 = tensor.empty() : tensor<1x16x112x112xf32>
+    %1 = linalg.fill ins(%cst_209 : f32) outs(%0 : tensor<1x16x112x112xf32>) -> tensor<1x16x112x112xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded, %cst_208 : tensor<1x3x226x226xf32>, tensor<16x3x3x3xf32>) outs(%1 : tensor<1x16x112x112xf32>) -> tensor<1x16x112x112xf32>
+    %3 = arith.cmpi eq, %false, %false : i1
+    cf.assert %3, "training is not supported for now"
+    %4 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %cst_205, %cst_204, %cst_207, %cst_206 : tensor<1x16x112x112xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>) outs(%2 : tensor<1x16x112x112xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x16x112x112xf32>
+    %5 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4 : tensor<1x16x112x112xf32>) outs(%0 : tensor<1x16x112x112xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x16x112x112xf32>
+    %6 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%5 : tensor<1x16x112x112xf32>) outs(%0 : tensor<1x16x112x112xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x16x112x112xf32>
+    %7 = tensor.empty() : tensor<i64>
+    %8 = linalg.fill ins(%c6_i64 : i64) outs(%7 : tensor<i64>) -> tensor<i64>
+    %9 = tensor.empty() : tensor<f32>
+    %10 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = []} ins(%8 : tensor<i64>) outs(%9 : tensor<f32>) {
+    ^bb0(%in: i64, %out: f32):
+      %362 = arith.sitofp %in : i64 to f32
+      linalg.yield %362 : f32
+    } -> tensor<f32>
+    %11 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%6, %10 : tensor<1x16x112x112xf32>, tensor<f32>) outs(%0 : tensor<1x16x112x112xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x16x112x112xf32>
+    %12 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%11 : tensor<1x16x112x112xf32>) outs(%0 : tensor<1x16x112x112xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x16x112x112xf32>
+    %13 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%12, %4 : tensor<1x16x112x112xf32>, tensor<1x16x112x112xf32>) outs(%0 : tensor<1x16x112x112xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x16x112x112xf32>
+    %padded_216 = tensor.pad %13 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x16x112x112xf32> to tensor<1x16x114x114xf32>
+    %14 = tensor.empty() : tensor<1x16x56x56xf32>
+    %15 = linalg.fill ins(%cst_209 : f32) outs(%14 : tensor<1x16x56x56xf32>) -> tensor<1x16x56x56xf32>
+    %collapsed = tensor.collapse_shape %cst_203 [[0, 1], [2], [3]] : tensor<16x1x3x3xf32> into tensor<16x3x3xf32>
+    %16 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_216, %collapsed : tensor<1x16x114x114xf32>, tensor<16x3x3xf32>) outs(%15 : tensor<1x16x56x56xf32>) -> tensor<1x16x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %17 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%16, %cst_200, %cst_199, %cst_202, %cst_201 : tensor<1x16x56x56xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>) outs(%16 : tensor<1x16x56x56xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x16x56x56xf32>
+    %18 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%17 : tensor<1x16x56x56xf32>) outs(%14 : tensor<1x16x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x16x56x56xf32>
+    %19 = tensor.empty() : tensor<1x16x1x1xf32>
+    %20 = linalg.fill ins(%cst_209 : f32) outs(%19 : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+    %21 = tensor.empty() : tensor<56x56xf32>
+    %22 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%18, %21 : tensor<1x16x56x56xf32>, tensor<56x56xf32>) outs(%20 : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+    %23 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%22 : tensor<1x16x1x1xf32>) outs(%19 : tensor<1x16x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_213 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x16x1x1xf32>
+    %24 = tensor.empty() : tensor<1x8x1x1xf32>
+    %25 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_197 : tensor<8xf32>) outs(%24 : tensor<1x8x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x8x1x1xf32>
+    %26 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%23, %cst_198 : tensor<1x16x1x1xf32>, tensor<8x16x1x1xf32>) outs(%25 : tensor<1x8x1x1xf32>) -> tensor<1x8x1x1xf32>
+    %27 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%26 : tensor<1x8x1x1xf32>) outs(%24 : tensor<1x8x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x8x1x1xf32>
+    %28 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_195 : tensor<16xf32>) outs(%19 : tensor<1x16x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x16x1x1xf32>
+    %29 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%27, %cst_196 : tensor<1x8x1x1xf32>, tensor<16x8x1x1xf32>) outs(%28 : tensor<1x16x1x1xf32>) -> tensor<1x16x1x1xf32>
+    %30 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%29 : tensor<1x16x1x1xf32>) outs(%19 : tensor<1x16x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x16x1x1xf32>
+    %31 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%30 : tensor<1x16x1x1xf32>) outs(%19 : tensor<1x16x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x16x1x1xf32>
+    %32 = linalg.fill ins(%c1_i64 : i64) outs(%7 : tensor<i64>) -> tensor<i64>
+    %33 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = []} ins(%32 : tensor<i64>) outs(%9 : tensor<f32>) {
+    ^bb0(%in: i64, %out: f32):
+      %362 = arith.sitofp %in : i64 to f32
+      linalg.yield %362 : f32
+    } -> tensor<f32>
+    %34 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %31 : tensor<f32>, tensor<1x16x1x1xf32>) outs(%19 : tensor<1x16x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x16x1x1xf32>
+    %35 = linalg.fill ins(%c0_i64 : i64) outs(%7 : tensor<i64>) -> tensor<i64>
+    %36 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = []} ins(%35 : tensor<i64>) outs(%9 : tensor<f32>) {
+    ^bb0(%in: i64, %out: f32):
+      %362 = arith.sitofp %in : i64 to f32
+      linalg.yield %362 : f32
+    } -> tensor<f32>
+    %37 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %34 : tensor<f32>, tensor<1x16x1x1xf32>) outs(%19 : tensor<1x16x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x16x1x1xf32>
+    %38 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%37, %18 : tensor<1x16x1x1xf32>, tensor<1x16x56x56xf32>) outs(%14 : tensor<1x16x56x56xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x16x56x56xf32>
+    %39 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%38, %cst_194 : tensor<1x16x56x56xf32>, tensor<16x16x1x1xf32>) outs(%15 : tensor<1x16x56x56xf32>) -> tensor<1x16x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %40 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%39, %cst_191, %cst_190, %cst_193, %cst_192 : tensor<1x16x56x56xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>) outs(%39 : tensor<1x16x56x56xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x16x56x56xf32>
+    %41 = tensor.empty() : tensor<1x72x56x56xf32>
+    %42 = linalg.fill ins(%cst_209 : f32) outs(%41 : tensor<1x72x56x56xf32>) -> tensor<1x72x56x56xf32>
+    %43 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%40, %cst_189 : tensor<1x16x56x56xf32>, tensor<72x16x1x1xf32>) outs(%42 : tensor<1x72x56x56xf32>) -> tensor<1x72x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %44 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%43, %cst_186, %cst_185, %cst_188, %cst_187 : tensor<1x72x56x56xf32>, tensor<72xf32>, tensor<72xf32>, tensor<72xf32>, tensor<72xf32>) outs(%43 : tensor<1x72x56x56xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x72x56x56xf32>
+    %45 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%44 : tensor<1x72x56x56xf32>) outs(%41 : tensor<1x72x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x72x56x56xf32>
+    %padded_217 = tensor.pad %45 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x72x56x56xf32> to tensor<1x72x58x58xf32>
+    %46 = tensor.empty() : tensor<1x72x28x28xf32>
+    %47 = linalg.fill ins(%cst_209 : f32) outs(%46 : tensor<1x72x28x28xf32>) -> tensor<1x72x28x28xf32>
+    %collapsed_218 = tensor.collapse_shape %cst_184 [[0, 1], [2], [3]] : tensor<72x1x3x3xf32> into tensor<72x3x3xf32>
+    %48 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_217, %collapsed_218 : tensor<1x72x58x58xf32>, tensor<72x3x3xf32>) outs(%47 : tensor<1x72x28x28xf32>) -> tensor<1x72x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %49 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%48, %cst_181, %cst_180, %cst_183, %cst_182 : tensor<1x72x28x28xf32>, tensor<72xf32>, tensor<72xf32>, tensor<72xf32>, tensor<72xf32>) outs(%48 : tensor<1x72x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x72x28x28xf32>
+    %50 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%49 : tensor<1x72x28x28xf32>) outs(%46 : tensor<1x72x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x72x28x28xf32>
+    %51 = tensor.empty() : tensor<1x24x28x28xf32>
+    %52 = linalg.fill ins(%cst_209 : f32) outs(%51 : tensor<1x24x28x28xf32>) -> tensor<1x24x28x28xf32>
+    %53 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%50, %cst_179 : tensor<1x72x28x28xf32>, tensor<24x72x1x1xf32>) outs(%52 : tensor<1x24x28x28xf32>) -> tensor<1x24x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %54 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%53, %cst_176, %cst_175, %cst_178, %cst_177 : tensor<1x24x28x28xf32>, tensor<24xf32>, tensor<24xf32>, tensor<24xf32>, tensor<24xf32>) outs(%53 : tensor<1x24x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x24x28x28xf32>
+    %55 = tensor.empty() : tensor<1x88x28x28xf32>
+    %56 = linalg.fill ins(%cst_209 : f32) outs(%55 : tensor<1x88x28x28xf32>) -> tensor<1x88x28x28xf32>
+    %57 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%54, %cst_174 : tensor<1x24x28x28xf32>, tensor<88x24x1x1xf32>) outs(%56 : tensor<1x88x28x28xf32>) -> tensor<1x88x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %58 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%57, %cst_171, %cst_170, %cst_173, %cst_172 : tensor<1x88x28x28xf32>, tensor<88xf32>, tensor<88xf32>, tensor<88xf32>, tensor<88xf32>) outs(%57 : tensor<1x88x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x88x28x28xf32>
+    %59 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%58 : tensor<1x88x28x28xf32>) outs(%55 : tensor<1x88x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x88x28x28xf32>
+    %padded_219 = tensor.pad %59 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x88x28x28xf32> to tensor<1x88x30x30xf32>
+    %collapsed_220 = tensor.collapse_shape %cst_169 [[0, 1], [2], [3]] : tensor<88x1x3x3xf32> into tensor<88x3x3xf32>
+    %60 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_219, %collapsed_220 : tensor<1x88x30x30xf32>, tensor<88x3x3xf32>) outs(%56 : tensor<1x88x28x28xf32>) -> tensor<1x88x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %61 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%60, %cst_166, %cst_165, %cst_168, %cst_167 : tensor<1x88x28x28xf32>, tensor<88xf32>, tensor<88xf32>, tensor<88xf32>, tensor<88xf32>) outs(%60 : tensor<1x88x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x88x28x28xf32>
+    %62 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%61 : tensor<1x88x28x28xf32>) outs(%55 : tensor<1x88x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x88x28x28xf32>
+    %63 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%62, %cst_164 : tensor<1x88x28x28xf32>, tensor<24x88x1x1xf32>) outs(%52 : tensor<1x24x28x28xf32>) -> tensor<1x24x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %64 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%63, %cst_161, %cst_160, %cst_163, %cst_162 : tensor<1x24x28x28xf32>, tensor<24xf32>, tensor<24xf32>, tensor<24xf32>, tensor<24xf32>) outs(%63 : tensor<1x24x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x24x28x28xf32>
+    %65 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%64, %54 : tensor<1x24x28x28xf32>, tensor<1x24x28x28xf32>) outs(%51 : tensor<1x24x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x24x28x28xf32>
+    %66 = tensor.empty() : tensor<1x96x28x28xf32>
+    %67 = linalg.fill ins(%cst_209 : f32) outs(%66 : tensor<1x96x28x28xf32>) -> tensor<1x96x28x28xf32>
+    %68 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%65, %cst_159 : tensor<1x24x28x28xf32>, tensor<96x24x1x1xf32>) outs(%67 : tensor<1x96x28x28xf32>) -> tensor<1x96x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %69 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%68, %cst_156, %cst_155, %cst_158, %cst_157 : tensor<1x96x28x28xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>) outs(%68 : tensor<1x96x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x96x28x28xf32>
+    %70 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%69 : tensor<1x96x28x28xf32>) outs(%66 : tensor<1x96x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x28x28xf32>
+    %71 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%70 : tensor<1x96x28x28xf32>) outs(%66 : tensor<1x96x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x96x28x28xf32>
+    %72 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%71, %10 : tensor<1x96x28x28xf32>, tensor<f32>) outs(%66 : tensor<1x96x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x96x28x28xf32>
+    %73 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%72 : tensor<1x96x28x28xf32>) outs(%66 : tensor<1x96x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x28x28xf32>
+    %74 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%73, %69 : tensor<1x96x28x28xf32>, tensor<1x96x28x28xf32>) outs(%66 : tensor<1x96x28x28xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x28x28xf32>
+    %padded_221 = tensor.pad %74 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x96x28x28xf32> to tensor<1x96x32x32xf32>
+    %75 = tensor.empty() : tensor<1x96x14x14xf32>
+    %76 = linalg.fill ins(%cst_209 : f32) outs(%75 : tensor<1x96x14x14xf32>) -> tensor<1x96x14x14xf32>
+    %collapsed_222 = tensor.collapse_shape %cst_154 [[0, 1], [2], [3]] : tensor<96x1x5x5xf32> into tensor<96x5x5xf32>
+    %77 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_221, %collapsed_222 : tensor<1x96x32x32xf32>, tensor<96x5x5xf32>) outs(%76 : tensor<1x96x14x14xf32>) -> tensor<1x96x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %78 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%77, %cst_151, %cst_150, %cst_153, %cst_152 : tensor<1x96x14x14xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>) outs(%77 : tensor<1x96x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x96x14x14xf32>
+    %79 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%78 : tensor<1x96x14x14xf32>) outs(%75 : tensor<1x96x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x14x14xf32>
+    %80 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%79 : tensor<1x96x14x14xf32>) outs(%75 : tensor<1x96x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x96x14x14xf32>
+    %81 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%80, %10 : tensor<1x96x14x14xf32>, tensor<f32>) outs(%75 : tensor<1x96x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x96x14x14xf32>
+    %82 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%81 : tensor<1x96x14x14xf32>) outs(%75 : tensor<1x96x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x14x14xf32>
+    %83 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%82, %78 : tensor<1x96x14x14xf32>, tensor<1x96x14x14xf32>) outs(%75 : tensor<1x96x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x14x14xf32>
+    %84 = tensor.empty() : tensor<1x96x1x1xf32>
+    %85 = linalg.fill ins(%cst_209 : f32) outs(%84 : tensor<1x96x1x1xf32>) -> tensor<1x96x1x1xf32>
+    %86 = tensor.empty() : tensor<14x14xf32>
+    %87 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%83, %86 : tensor<1x96x14x14xf32>, tensor<14x14xf32>) outs(%85 : tensor<1x96x1x1xf32>) -> tensor<1x96x1x1xf32>
+    %88 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%87 : tensor<1x96x1x1xf32>) outs(%84 : tensor<1x96x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_214 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x1x1xf32>
+    %89 = tensor.empty() : tensor<1x24x1x1xf32>
+    %90 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_148 : tensor<24xf32>) outs(%89 : tensor<1x24x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x24x1x1xf32>
+    %91 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%88, %cst_149 : tensor<1x96x1x1xf32>, tensor<24x96x1x1xf32>) outs(%90 : tensor<1x24x1x1xf32>) -> tensor<1x24x1x1xf32>
+    %92 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%91 : tensor<1x24x1x1xf32>) outs(%89 : tensor<1x24x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x24x1x1xf32>
+    %93 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_146 : tensor<96xf32>) outs(%84 : tensor<1x96x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x96x1x1xf32>
+    %94 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%92, %cst_147 : tensor<1x24x1x1xf32>, tensor<96x24x1x1xf32>) outs(%93 : tensor<1x96x1x1xf32>) -> tensor<1x96x1x1xf32>
+    %95 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%94 : tensor<1x96x1x1xf32>) outs(%84 : tensor<1x96x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x1x1xf32>
+    %96 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%95 : tensor<1x96x1x1xf32>) outs(%84 : tensor<1x96x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x1x1xf32>
+    %97 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %96 : tensor<f32>, tensor<1x96x1x1xf32>) outs(%84 : tensor<1x96x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x96x1x1xf32>
+    %98 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %97 : tensor<f32>, tensor<1x96x1x1xf32>) outs(%84 : tensor<1x96x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x96x1x1xf32>
+    %99 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%98, %83 : tensor<1x96x1x1xf32>, tensor<1x96x14x14xf32>) outs(%75 : tensor<1x96x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x14x14xf32>
+    %100 = tensor.empty() : tensor<1x40x14x14xf32>
+    %101 = linalg.fill ins(%cst_209 : f32) outs(%100 : tensor<1x40x14x14xf32>) -> tensor<1x40x14x14xf32>
+    %102 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%99, %cst_145 : tensor<1x96x14x14xf32>, tensor<40x96x1x1xf32>) outs(%101 : tensor<1x40x14x14xf32>) -> tensor<1x40x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %103 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%102, %cst_142, %cst_141, %cst_144, %cst_143 : tensor<1x40x14x14xf32>, tensor<40xf32>, tensor<40xf32>, tensor<40xf32>, tensor<40xf32>) outs(%102 : tensor<1x40x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x40x14x14xf32>
+    %104 = tensor.empty() : tensor<1x240x14x14xf32>
+    %105 = linalg.fill ins(%cst_209 : f32) outs(%104 : tensor<1x240x14x14xf32>) -> tensor<1x240x14x14xf32>
+    %106 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%103, %cst_140 : tensor<1x40x14x14xf32>, tensor<240x40x1x1xf32>) outs(%105 : tensor<1x240x14x14xf32>) -> tensor<1x240x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %107 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%106, %cst_137, %cst_136, %cst_139, %cst_138 : tensor<1x240x14x14xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>) outs(%106 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x240x14x14xf32>
+    %108 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%107 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %109 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%108 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %110 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%109, %10 : tensor<1x240x14x14xf32>, tensor<f32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %111 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%110 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %112 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%111, %107 : tensor<1x240x14x14xf32>, tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %padded_223 = tensor.pad %112 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x240x14x14xf32> to tensor<1x240x18x18xf32>
+    %collapsed_224 = tensor.collapse_shape %cst_135 [[0, 1], [2], [3]] : tensor<240x1x5x5xf32> into tensor<240x5x5xf32>
+    %113 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_223, %collapsed_224 : tensor<1x240x18x18xf32>, tensor<240x5x5xf32>) outs(%105 : tensor<1x240x14x14xf32>) -> tensor<1x240x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %114 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%113, %cst_132, %cst_131, %cst_134, %cst_133 : tensor<1x240x14x14xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>) outs(%113 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x240x14x14xf32>
+    %115 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%114 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %116 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%115 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %117 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%116, %10 : tensor<1x240x14x14xf32>, tensor<f32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %118 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%117 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %119 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%118, %114 : tensor<1x240x14x14xf32>, tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %120 = tensor.empty() : tensor<1x240x1x1xf32>
+    %121 = linalg.fill ins(%cst_209 : f32) outs(%120 : tensor<1x240x1x1xf32>) -> tensor<1x240x1x1xf32>
+    %122 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%119, %86 : tensor<1x240x14x14xf32>, tensor<14x14xf32>) outs(%121 : tensor<1x240x1x1xf32>) -> tensor<1x240x1x1xf32>
+    %123 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%122 : tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_214 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x1x1xf32>
+    %124 = tensor.empty() : tensor<1x64x1x1xf32>
+    %125 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_129 : tensor<64xf32>) outs(%124 : tensor<1x64x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x64x1x1xf32>
+    %126 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%123, %cst_130 : tensor<1x240x1x1xf32>, tensor<64x240x1x1xf32>) outs(%125 : tensor<1x64x1x1xf32>) -> tensor<1x64x1x1xf32>
+    %127 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%126 : tensor<1x64x1x1xf32>) outs(%124 : tensor<1x64x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x64x1x1xf32>
+    %128 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_127 : tensor<240xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x240x1x1xf32>
+    %129 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%127, %cst_128 : tensor<1x64x1x1xf32>, tensor<240x64x1x1xf32>) outs(%128 : tensor<1x240x1x1xf32>) -> tensor<1x240x1x1xf32>
+    %130 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%129 : tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x1x1xf32>
+    %131 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%130 : tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x1x1xf32>
+    %132 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %131 : tensor<f32>, tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x1x1xf32>
+    %133 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %132 : tensor<f32>, tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x1x1xf32>
+    %134 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%133, %119 : tensor<1x240x1x1xf32>, tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %135 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%134, %cst_126 : tensor<1x240x14x14xf32>, tensor<40x240x1x1xf32>) outs(%101 : tensor<1x40x14x14xf32>) -> tensor<1x40x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %136 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%135, %cst_123, %cst_122, %cst_125, %cst_124 : tensor<1x40x14x14xf32>, tensor<40xf32>, tensor<40xf32>, tensor<40xf32>, tensor<40xf32>) outs(%135 : tensor<1x40x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x40x14x14xf32>
+    %137 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%136, %103 : tensor<1x40x14x14xf32>, tensor<1x40x14x14xf32>) outs(%100 : tensor<1x40x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x40x14x14xf32>
+    %138 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%137, %cst_121 : tensor<1x40x14x14xf32>, tensor<240x40x1x1xf32>) outs(%105 : tensor<1x240x14x14xf32>) -> tensor<1x240x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %139 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%138, %cst_118, %cst_117, %cst_120, %cst_119 : tensor<1x240x14x14xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>) outs(%138 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x240x14x14xf32>
+    %140 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%139 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %141 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%140 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %142 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%141, %10 : tensor<1x240x14x14xf32>, tensor<f32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %143 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%142 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %144 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%143, %139 : tensor<1x240x14x14xf32>, tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %padded_225 = tensor.pad %144 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x240x14x14xf32> to tensor<1x240x18x18xf32>
+    %collapsed_226 = tensor.collapse_shape %cst_116 [[0, 1], [2], [3]] : tensor<240x1x5x5xf32> into tensor<240x5x5xf32>
+    %145 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_225, %collapsed_226 : tensor<1x240x18x18xf32>, tensor<240x5x5xf32>) outs(%105 : tensor<1x240x14x14xf32>) -> tensor<1x240x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %146 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%145, %cst_113, %cst_112, %cst_115, %cst_114 : tensor<1x240x14x14xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>) outs(%145 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x240x14x14xf32>
+    %147 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%146 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %148 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%147 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %149 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%148, %10 : tensor<1x240x14x14xf32>, tensor<f32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x14x14xf32>
+    %150 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%149 : tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %151 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%150, %146 : tensor<1x240x14x14xf32>, tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %152 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%151, %86 : tensor<1x240x14x14xf32>, tensor<14x14xf32>) outs(%121 : tensor<1x240x1x1xf32>) -> tensor<1x240x1x1xf32>
+    %153 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%152 : tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_214 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x1x1xf32>
+    %154 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_110 : tensor<64xf32>) outs(%124 : tensor<1x64x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x64x1x1xf32>
+    %155 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%153, %cst_111 : tensor<1x240x1x1xf32>, tensor<64x240x1x1xf32>) outs(%154 : tensor<1x64x1x1xf32>) -> tensor<1x64x1x1xf32>
+    %156 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%155 : tensor<1x64x1x1xf32>) outs(%124 : tensor<1x64x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x64x1x1xf32>
+    %157 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_108 : tensor<240xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x240x1x1xf32>
+    %158 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%156, %cst_109 : tensor<1x64x1x1xf32>, tensor<240x64x1x1xf32>) outs(%157 : tensor<1x240x1x1xf32>) -> tensor<1x240x1x1xf32>
+    %159 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%158 : tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x1x1xf32>
+    %160 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%159 : tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x1x1xf32>
+    %161 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %160 : tensor<f32>, tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x1x1xf32>
+    %162 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %161 : tensor<f32>, tensor<1x240x1x1xf32>) outs(%120 : tensor<1x240x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x240x1x1xf32>
+    %163 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%162, %151 : tensor<1x240x1x1xf32>, tensor<1x240x14x14xf32>) outs(%104 : tensor<1x240x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x240x14x14xf32>
+    %164 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%163, %cst_107 : tensor<1x240x14x14xf32>, tensor<40x240x1x1xf32>) outs(%101 : tensor<1x40x14x14xf32>) -> tensor<1x40x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %165 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%164, %cst_104, %cst_103, %cst_106, %cst_105 : tensor<1x40x14x14xf32>, tensor<40xf32>, tensor<40xf32>, tensor<40xf32>, tensor<40xf32>) outs(%164 : tensor<1x40x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x40x14x14xf32>
+    %166 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%165, %137 : tensor<1x40x14x14xf32>, tensor<1x40x14x14xf32>) outs(%100 : tensor<1x40x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x40x14x14xf32>
+    %167 = tensor.empty() : tensor<1x120x14x14xf32>
+    %168 = linalg.fill ins(%cst_209 : f32) outs(%167 : tensor<1x120x14x14xf32>) -> tensor<1x120x14x14xf32>
+    %169 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%166, %cst_102 : tensor<1x40x14x14xf32>, tensor<120x40x1x1xf32>) outs(%168 : tensor<1x120x14x14xf32>) -> tensor<1x120x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %170 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%169, %cst_99, %cst_98, %cst_101, %cst_100 : tensor<1x120x14x14xf32>, tensor<120xf32>, tensor<120xf32>, tensor<120xf32>, tensor<120xf32>) outs(%169 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x120x14x14xf32>
+    %171 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%170 : tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x14x14xf32>
+    %172 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%171 : tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x120x14x14xf32>
+    %173 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%172, %10 : tensor<1x120x14x14xf32>, tensor<f32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x120x14x14xf32>
+    %174 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%173 : tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x14x14xf32>
+    %175 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%174, %170 : tensor<1x120x14x14xf32>, tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x14x14xf32>
+    %padded_227 = tensor.pad %175 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x120x14x14xf32> to tensor<1x120x18x18xf32>
+    %collapsed_228 = tensor.collapse_shape %cst_97 [[0, 1], [2], [3]] : tensor<120x1x5x5xf32> into tensor<120x5x5xf32>
+    %176 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_227, %collapsed_228 : tensor<1x120x18x18xf32>, tensor<120x5x5xf32>) outs(%168 : tensor<1x120x14x14xf32>) -> tensor<1x120x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %177 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%176, %cst_94, %cst_93, %cst_96, %cst_95 : tensor<1x120x14x14xf32>, tensor<120xf32>, tensor<120xf32>, tensor<120xf32>, tensor<120xf32>) outs(%176 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x120x14x14xf32>
+    %178 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%177 : tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x14x14xf32>
+    %179 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%178 : tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x120x14x14xf32>
+    %180 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%179, %10 : tensor<1x120x14x14xf32>, tensor<f32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x120x14x14xf32>
+    %181 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%180 : tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x14x14xf32>
+    %182 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%181, %177 : tensor<1x120x14x14xf32>, tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x14x14xf32>
+    %183 = tensor.empty() : tensor<1x120x1x1xf32>
+    %184 = linalg.fill ins(%cst_209 : f32) outs(%183 : tensor<1x120x1x1xf32>) -> tensor<1x120x1x1xf32>
+    %185 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%182, %86 : tensor<1x120x14x14xf32>, tensor<14x14xf32>) outs(%184 : tensor<1x120x1x1xf32>) -> tensor<1x120x1x1xf32>
+    %186 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%185 : tensor<1x120x1x1xf32>) outs(%183 : tensor<1x120x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_214 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x1x1xf32>
+    %187 = tensor.empty() : tensor<1x32x1x1xf32>
+    %188 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_91 : tensor<32xf32>) outs(%187 : tensor<1x32x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x32x1x1xf32>
+    %189 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%186, %cst_92 : tensor<1x120x1x1xf32>, tensor<32x120x1x1xf32>) outs(%188 : tensor<1x32x1x1xf32>) -> tensor<1x32x1x1xf32>
+    %190 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%189 : tensor<1x32x1x1xf32>) outs(%187 : tensor<1x32x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x32x1x1xf32>
+    %191 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_89 : tensor<120xf32>) outs(%183 : tensor<1x120x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x120x1x1xf32>
+    %192 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%190, %cst_90 : tensor<1x32x1x1xf32>, tensor<120x32x1x1xf32>) outs(%191 : tensor<1x120x1x1xf32>) -> tensor<1x120x1x1xf32>
+    %193 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%192 : tensor<1x120x1x1xf32>) outs(%183 : tensor<1x120x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x1x1xf32>
+    %194 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%193 : tensor<1x120x1x1xf32>) outs(%183 : tensor<1x120x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x1x1xf32>
+    %195 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %194 : tensor<f32>, tensor<1x120x1x1xf32>) outs(%183 : tensor<1x120x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x120x1x1xf32>
+    %196 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %195 : tensor<f32>, tensor<1x120x1x1xf32>) outs(%183 : tensor<1x120x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x120x1x1xf32>
+    %197 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%196, %182 : tensor<1x120x1x1xf32>, tensor<1x120x14x14xf32>) outs(%167 : tensor<1x120x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x120x14x14xf32>
+    %198 = tensor.empty() : tensor<1x48x14x14xf32>
+    %199 = linalg.fill ins(%cst_209 : f32) outs(%198 : tensor<1x48x14x14xf32>) -> tensor<1x48x14x14xf32>
+    %200 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%197, %cst_88 : tensor<1x120x14x14xf32>, tensor<48x120x1x1xf32>) outs(%199 : tensor<1x48x14x14xf32>) -> tensor<1x48x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %201 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%200, %cst_85, %cst_84, %cst_87, %cst_86 : tensor<1x48x14x14xf32>, tensor<48xf32>, tensor<48xf32>, tensor<48xf32>, tensor<48xf32>) outs(%200 : tensor<1x48x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x48x14x14xf32>
+    %202 = tensor.empty() : tensor<1x144x14x14xf32>
+    %203 = linalg.fill ins(%cst_209 : f32) outs(%202 : tensor<1x144x14x14xf32>) -> tensor<1x144x14x14xf32>
+    %204 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%201, %cst_83 : tensor<1x48x14x14xf32>, tensor<144x48x1x1xf32>) outs(%203 : tensor<1x144x14x14xf32>) -> tensor<1x144x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %205 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%204, %cst_80, %cst_79, %cst_82, %cst_81 : tensor<1x144x14x14xf32>, tensor<144xf32>, tensor<144xf32>, tensor<144xf32>, tensor<144xf32>) outs(%204 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x144x14x14xf32>
+    %206 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%205 : tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x14x14xf32>
+    %207 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%206 : tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x14x14xf32>
+    %208 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%207, %10 : tensor<1x144x14x14xf32>, tensor<f32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x14x14xf32>
+    %209 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%208 : tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x14x14xf32>
+    %210 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%209, %205 : tensor<1x144x14x14xf32>, tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x14x14xf32>
+    %padded_229 = tensor.pad %210 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x144x14x14xf32> to tensor<1x144x18x18xf32>
+    %collapsed_230 = tensor.collapse_shape %cst_78 [[0, 1], [2], [3]] : tensor<144x1x5x5xf32> into tensor<144x5x5xf32>
+    %211 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_229, %collapsed_230 : tensor<1x144x18x18xf32>, tensor<144x5x5xf32>) outs(%203 : tensor<1x144x14x14xf32>) -> tensor<1x144x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %212 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%211, %cst_75, %cst_74, %cst_77, %cst_76 : tensor<1x144x14x14xf32>, tensor<144xf32>, tensor<144xf32>, tensor<144xf32>, tensor<144xf32>) outs(%211 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x144x14x14xf32>
+    %213 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%212 : tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x14x14xf32>
+    %214 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%213 : tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x14x14xf32>
+    %215 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%214, %10 : tensor<1x144x14x14xf32>, tensor<f32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x14x14xf32>
+    %216 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%215 : tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x14x14xf32>
+    %217 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%216, %212 : tensor<1x144x14x14xf32>, tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x14x14xf32>
+    %218 = tensor.empty() : tensor<1x144x1x1xf32>
+    %219 = linalg.fill ins(%cst_209 : f32) outs(%218 : tensor<1x144x1x1xf32>) -> tensor<1x144x1x1xf32>
+    %220 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%217, %86 : tensor<1x144x14x14xf32>, tensor<14x14xf32>) outs(%219 : tensor<1x144x1x1xf32>) -> tensor<1x144x1x1xf32>
+    %221 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%220 : tensor<1x144x1x1xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_214 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x1x1xf32>
+    %222 = tensor.empty() : tensor<1x40x1x1xf32>
+    %223 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_72 : tensor<40xf32>) outs(%222 : tensor<1x40x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x40x1x1xf32>
+    %224 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%221, %cst_73 : tensor<1x144x1x1xf32>, tensor<40x144x1x1xf32>) outs(%223 : tensor<1x40x1x1xf32>) -> tensor<1x40x1x1xf32>
+    %225 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%224 : tensor<1x40x1x1xf32>) outs(%222 : tensor<1x40x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x40x1x1xf32>
+    %226 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_70 : tensor<144xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x144x1x1xf32>
+    %227 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%225, %cst_71 : tensor<1x40x1x1xf32>, tensor<144x40x1x1xf32>) outs(%226 : tensor<1x144x1x1xf32>) -> tensor<1x144x1x1xf32>
+    %228 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%227 : tensor<1x144x1x1xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x1x1xf32>
+    %229 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%228 : tensor<1x144x1x1xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x1x1xf32>
+    %230 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %229 : tensor<f32>, tensor<1x144x1x1xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x1x1xf32>
+    %231 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %230 : tensor<f32>, tensor<1x144x1x1xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x1x1xf32>
+    %232 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%231, %217 : tensor<1x144x1x1xf32>, tensor<1x144x14x14xf32>) outs(%202 : tensor<1x144x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x144x14x14xf32>
+    %233 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%232, %cst_69 : tensor<1x144x14x14xf32>, tensor<48x144x1x1xf32>) outs(%199 : tensor<1x48x14x14xf32>) -> tensor<1x48x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %234 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%233, %cst_66, %cst_65, %cst_68, %cst_67 : tensor<1x48x14x14xf32>, tensor<48xf32>, tensor<48xf32>, tensor<48xf32>, tensor<48xf32>) outs(%233 : tensor<1x48x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x48x14x14xf32>
+    %235 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%234, %201 : tensor<1x48x14x14xf32>, tensor<1x48x14x14xf32>) outs(%198 : tensor<1x48x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x48x14x14xf32>
+    %236 = tensor.empty() : tensor<1x288x14x14xf32>
+    %237 = linalg.fill ins(%cst_209 : f32) outs(%236 : tensor<1x288x14x14xf32>) -> tensor<1x288x14x14xf32>
+    %238 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%235, %cst_64 : tensor<1x48x14x14xf32>, tensor<288x48x1x1xf32>) outs(%237 : tensor<1x288x14x14xf32>) -> tensor<1x288x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %239 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%238, %cst_61, %cst_60, %cst_63, %cst_62 : tensor<1x288x14x14xf32>, tensor<288xf32>, tensor<288xf32>, tensor<288xf32>, tensor<288xf32>) outs(%238 : tensor<1x288x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x288x14x14xf32>
+    %240 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%239 : tensor<1x288x14x14xf32>) outs(%236 : tensor<1x288x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x14x14xf32>
+    %241 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%240 : tensor<1x288x14x14xf32>) outs(%236 : tensor<1x288x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x288x14x14xf32>
+    %242 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%241, %10 : tensor<1x288x14x14xf32>, tensor<f32>) outs(%236 : tensor<1x288x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x288x14x14xf32>
+    %243 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%242 : tensor<1x288x14x14xf32>) outs(%236 : tensor<1x288x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x14x14xf32>
+    %244 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%243, %239 : tensor<1x288x14x14xf32>, tensor<1x288x14x14xf32>) outs(%236 : tensor<1x288x14x14xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x14x14xf32>
+    %padded_231 = tensor.pad %244 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x288x14x14xf32> to tensor<1x288x18x18xf32>
+    %245 = tensor.empty() : tensor<1x288x7x7xf32>
+    %246 = linalg.fill ins(%cst_209 : f32) outs(%245 : tensor<1x288x7x7xf32>) -> tensor<1x288x7x7xf32>
+    %collapsed_232 = tensor.collapse_shape %cst_59 [[0, 1], [2], [3]] : tensor<288x1x5x5xf32> into tensor<288x5x5xf32>
+    %247 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_231, %collapsed_232 : tensor<1x288x18x18xf32>, tensor<288x5x5xf32>) outs(%246 : tensor<1x288x7x7xf32>) -> tensor<1x288x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %248 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%247, %cst_56, %cst_55, %cst_58, %cst_57 : tensor<1x288x7x7xf32>, tensor<288xf32>, tensor<288xf32>, tensor<288xf32>, tensor<288xf32>) outs(%247 : tensor<1x288x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x288x7x7xf32>
+    %249 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%248 : tensor<1x288x7x7xf32>) outs(%245 : tensor<1x288x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x7x7xf32>
+    %250 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%249 : tensor<1x288x7x7xf32>) outs(%245 : tensor<1x288x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x288x7x7xf32>
+    %251 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%250, %10 : tensor<1x288x7x7xf32>, tensor<f32>) outs(%245 : tensor<1x288x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x288x7x7xf32>
+    %252 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%251 : tensor<1x288x7x7xf32>) outs(%245 : tensor<1x288x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x7x7xf32>
+    %253 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%252, %248 : tensor<1x288x7x7xf32>, tensor<1x288x7x7xf32>) outs(%245 : tensor<1x288x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x7x7xf32>
+    %254 = tensor.empty() : tensor<1x288x1x1xf32>
+    %255 = linalg.fill ins(%cst_209 : f32) outs(%254 : tensor<1x288x1x1xf32>) -> tensor<1x288x1x1xf32>
+    %256 = tensor.empty() : tensor<7x7xf32>
+    %257 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%253, %256 : tensor<1x288x7x7xf32>, tensor<7x7xf32>) outs(%255 : tensor<1x288x1x1xf32>) -> tensor<1x288x1x1xf32>
+    %258 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%257 : tensor<1x288x1x1xf32>) outs(%254 : tensor<1x288x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_215 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x1x1xf32>
+    %259 = tensor.empty() : tensor<1x72x1x1xf32>
+    %260 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_53 : tensor<72xf32>) outs(%259 : tensor<1x72x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x72x1x1xf32>
+    %261 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%258, %cst_54 : tensor<1x288x1x1xf32>, tensor<72x288x1x1xf32>) outs(%260 : tensor<1x72x1x1xf32>) -> tensor<1x72x1x1xf32>
+    %262 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%261 : tensor<1x72x1x1xf32>) outs(%259 : tensor<1x72x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x72x1x1xf32>
+    %263 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_51 : tensor<288xf32>) outs(%254 : tensor<1x288x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x288x1x1xf32>
+    %264 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%262, %cst_52 : tensor<1x72x1x1xf32>, tensor<288x72x1x1xf32>) outs(%263 : tensor<1x288x1x1xf32>) -> tensor<1x288x1x1xf32>
+    %265 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%264 : tensor<1x288x1x1xf32>) outs(%254 : tensor<1x288x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x1x1xf32>
+    %266 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%265 : tensor<1x288x1x1xf32>) outs(%254 : tensor<1x288x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x1x1xf32>
+    %267 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %266 : tensor<f32>, tensor<1x288x1x1xf32>) outs(%254 : tensor<1x288x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x288x1x1xf32>
+    %268 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %267 : tensor<f32>, tensor<1x288x1x1xf32>) outs(%254 : tensor<1x288x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x288x1x1xf32>
+    %269 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%268, %253 : tensor<1x288x1x1xf32>, tensor<1x288x7x7xf32>) outs(%245 : tensor<1x288x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x288x7x7xf32>
+    %270 = tensor.empty() : tensor<1x96x7x7xf32>
+    %271 = linalg.fill ins(%cst_209 : f32) outs(%270 : tensor<1x96x7x7xf32>) -> tensor<1x96x7x7xf32>
+    %272 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%269, %cst_50 : tensor<1x288x7x7xf32>, tensor<96x288x1x1xf32>) outs(%271 : tensor<1x96x7x7xf32>) -> tensor<1x96x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %273 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%272, %cst_47, %cst_46, %cst_49, %cst_48 : tensor<1x96x7x7xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>) outs(%272 : tensor<1x96x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x96x7x7xf32>
+    %274 = tensor.empty() : tensor<1x576x7x7xf32>
+    %275 = linalg.fill ins(%cst_209 : f32) outs(%274 : tensor<1x576x7x7xf32>) -> tensor<1x576x7x7xf32>
+    %276 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%273, %cst_45 : tensor<1x96x7x7xf32>, tensor<576x96x1x1xf32>) outs(%275 : tensor<1x576x7x7xf32>) -> tensor<1x576x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %277 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%276, %cst_42, %cst_41, %cst_44, %cst_43 : tensor<1x576x7x7xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>) outs(%276 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x576x7x7xf32>
+    %278 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%277 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %279 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%278 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %280 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%279, %10 : tensor<1x576x7x7xf32>, tensor<f32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %281 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%280 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %282 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%281, %277 : tensor<1x576x7x7xf32>, tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %padded_233 = tensor.pad %282 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x576x7x7xf32> to tensor<1x576x11x11xf32>
+    %collapsed_234 = tensor.collapse_shape %cst_40 [[0, 1], [2], [3]] : tensor<576x1x5x5xf32> into tensor<576x5x5xf32>
+    %283 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_233, %collapsed_234 : tensor<1x576x11x11xf32>, tensor<576x5x5xf32>) outs(%275 : tensor<1x576x7x7xf32>) -> tensor<1x576x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %284 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%283, %cst_37, %cst_36, %cst_39, %cst_38 : tensor<1x576x7x7xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>) outs(%283 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x576x7x7xf32>
+    %285 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%284 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %286 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%285 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %287 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%286, %10 : tensor<1x576x7x7xf32>, tensor<f32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %288 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%287 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %289 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%288, %284 : tensor<1x576x7x7xf32>, tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %290 = tensor.empty() : tensor<1x576x1x1xf32>
+    %291 = linalg.fill ins(%cst_209 : f32) outs(%290 : tensor<1x576x1x1xf32>) -> tensor<1x576x1x1xf32>
+    %292 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%289, %256 : tensor<1x576x7x7xf32>, tensor<7x7xf32>) outs(%291 : tensor<1x576x1x1xf32>) -> tensor<1x576x1x1xf32>
+    %293 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%292 : tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_215 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x1x1xf32>
+    %294 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_34 : tensor<144xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x144x1x1xf32>
+    %295 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%293, %cst_35 : tensor<1x576x1x1xf32>, tensor<144x576x1x1xf32>) outs(%294 : tensor<1x144x1x1xf32>) -> tensor<1x144x1x1xf32>
+    %296 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%295 : tensor<1x144x1x1xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x1x1xf32>
+    %297 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_32 : tensor<576xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x576x1x1xf32>
+    %298 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%296, %cst_33 : tensor<1x144x1x1xf32>, tensor<576x144x1x1xf32>) outs(%297 : tensor<1x576x1x1xf32>) -> tensor<1x576x1x1xf32>
+    %299 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%298 : tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x1x1xf32>
+    %300 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%299 : tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x1x1xf32>
+    %301 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %300 : tensor<f32>, tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x1x1xf32>
+    %302 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %301 : tensor<f32>, tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x1x1xf32>
+    %303 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%302, %289 : tensor<1x576x1x1xf32>, tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %304 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%303, %cst_31 : tensor<1x576x7x7xf32>, tensor<96x576x1x1xf32>) outs(%271 : tensor<1x96x7x7xf32>) -> tensor<1x96x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %305 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%304, %cst_28, %cst_27, %cst_30, %cst_29 : tensor<1x96x7x7xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>) outs(%304 : tensor<1x96x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x96x7x7xf32>
+    %306 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%305, %273 : tensor<1x96x7x7xf32>, tensor<1x96x7x7xf32>) outs(%270 : tensor<1x96x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x7x7xf32>
+    %307 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%306, %cst_26 : tensor<1x96x7x7xf32>, tensor<576x96x1x1xf32>) outs(%275 : tensor<1x576x7x7xf32>) -> tensor<1x576x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %308 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%307, %cst_23, %cst_22, %cst_25, %cst_24 : tensor<1x576x7x7xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>) outs(%307 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x576x7x7xf32>
+    %309 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%308 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %310 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%309 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %311 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%310, %10 : tensor<1x576x7x7xf32>, tensor<f32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %312 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%311 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %313 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%312, %308 : tensor<1x576x7x7xf32>, tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %padded_235 = tensor.pad %313 low[0, 0, 2, 2] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_209 : f32
+    } : tensor<1x576x7x7xf32> to tensor<1x576x11x11xf32>
+    %collapsed_236 = tensor.collapse_shape %cst_21 [[0, 1], [2], [3]] : tensor<576x1x5x5xf32> into tensor<576x5x5xf32>
+    %314 = linalg.depthwise_conv_2d_nchw_chw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_235, %collapsed_236 : tensor<1x576x11x11xf32>, tensor<576x5x5xf32>) outs(%275 : tensor<1x576x7x7xf32>) -> tensor<1x576x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %315 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%314, %cst_18, %cst_17, %cst_20, %cst_19 : tensor<1x576x7x7xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>) outs(%314 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x576x7x7xf32>
+    %316 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%315 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %317 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%316 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %318 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%317, %10 : tensor<1x576x7x7xf32>, tensor<f32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %319 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%318 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %320 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%319, %315 : tensor<1x576x7x7xf32>, tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %321 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%320, %256 : tensor<1x576x7x7xf32>, tensor<7x7xf32>) outs(%291 : tensor<1x576x1x1xf32>) -> tensor<1x576x1x1xf32>
+    %322 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%321 : tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_215 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x1x1xf32>
+    %323 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_15 : tensor<144xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x144x1x1xf32>
+    %324 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%322, %cst_16 : tensor<1x576x1x1xf32>, tensor<144x576x1x1xf32>) outs(%323 : tensor<1x144x1x1xf32>) -> tensor<1x144x1x1xf32>
+    %325 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%324 : tensor<1x144x1x1xf32>) outs(%218 : tensor<1x144x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x144x1x1xf32>
+    %326 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_13 : tensor<576xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x576x1x1xf32>
+    %327 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%325, %cst_14 : tensor<1x144x1x1xf32>, tensor<576x144x1x1xf32>) outs(%326 : tensor<1x576x1x1xf32>) -> tensor<1x576x1x1xf32>
+    %328 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%327 : tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x1x1xf32>
+    %329 = linalg.generic {indexing_maps = [#map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%328 : tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x1x1xf32>
+    %330 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33, %329 : tensor<f32>, tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x1x1xf32>
+    %331 = linalg.generic {indexing_maps = [#map4, #map5, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %330 : tensor<f32>, tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf ogt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x1x1xf32>
+    %332 = linalg.generic {indexing_maps = [#map5, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%331, %320 : tensor<1x576x1x1xf32>, tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %333 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%332, %cst_12 : tensor<1x576x7x7xf32>, tensor<96x576x1x1xf32>) outs(%271 : tensor<1x96x7x7xf32>) -> tensor<1x96x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %334 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%333, %cst_9, %cst_8, %cst_11, %cst_10 : tensor<1x96x7x7xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>, tensor<96xf32>) outs(%333 : tensor<1x96x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x96x7x7xf32>
+    %335 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%334, %306 : tensor<1x96x7x7xf32>, tensor<1x96x7x7xf32>) outs(%270 : tensor<1x96x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x96x7x7xf32>
+    %336 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%335, %cst_7 : tensor<1x96x7x7xf32>, tensor<576x96x1x1xf32>) outs(%275 : tensor<1x576x7x7xf32>) -> tensor<1x576x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %337 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%336, %cst_4, %cst_3, %cst_6, %cst_5 : tensor<1x576x7x7xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>, tensor<576xf32>) outs(%336 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %in_239: f32, %in_240: f32, %in_241: f32, %out: f32):
+      %362 = arith.truncf %cst_210 : f64 to f32
+      %363 = arith.addf %in_241, %362 : f32
+      %364 = math.rsqrt %363 : f32
+      %365 = arith.subf %in, %in_240 : f32
+      %366 = arith.mulf %365, %364 : f32
+      %367 = arith.mulf %366, %in_238 : f32
+      %368 = arith.addf %367, %in_239 : f32
+      linalg.yield %368 : f32
+    } -> tensor<1x576x7x7xf32>
+    %338 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%337 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %339 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%338 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %340 = linalg.generic {indexing_maps = [#map2, #map4, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%339, %10 : tensor<1x576x7x7xf32>, tensor<f32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x576x7x7xf32>
+    %341 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%340 : tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %342 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%341, %337 : tensor<1x576x7x7xf32>, tensor<1x576x7x7xf32>) outs(%274 : tensor<1x576x7x7xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x7x7xf32>
+    %343 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%342, %256 : tensor<1x576x7x7xf32>, tensor<7x7xf32>) outs(%291 : tensor<1x576x1x1xf32>) -> tensor<1x576x1x1xf32>
+    %344 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%343 : tensor<1x576x1x1xf32>) outs(%290 : tensor<1x576x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_215 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x576x1x1xf32>
+    %collapsed_237 = tensor.collapse_shape %344 [[0], [1, 2, 3]] : tensor<1x576x1x1xf32> into tensor<1x576xf32>
+    %345 = tensor.empty() : tensor<576x1024xf32>
+    %346 = linalg.generic {indexing_maps = [#map6, #map7], iterator_types = ["parallel", "parallel"]} ins(%cst_2 : tensor<1024x576xf32>) outs(%345 : tensor<576x1024xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<576x1024xf32>
+    %347 = tensor.empty() : tensor<1x1024xf32>
+    %348 = linalg.fill ins(%cst_209 : f32) outs(%347 : tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    %349 = linalg.matmul ins(%collapsed_237, %346 : tensor<1x576xf32>, tensor<576x1024xf32>) outs(%348 : tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    %350 = linalg.generic {indexing_maps = [#map8, #map9, #map6], iterator_types = ["parallel", "parallel"]} ins(%349, %cst_1 : tensor<1x1024xf32>, tensor<1024xf32>) outs(%347 : tensor<1x1024xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x1024xf32>
+    %351 = linalg.generic {indexing_maps = [#map8, #map6], iterator_types = ["parallel", "parallel"]} ins(%350 : tensor<1x1024xf32>) outs(%347 : tensor<1x1024xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.addf %in, %cst_211 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x1024xf32>
+    %352 = linalg.generic {indexing_maps = [#map8, #map6], iterator_types = ["parallel", "parallel"]} ins(%351 : tensor<1x1024xf32>) outs(%347 : tensor<1x1024xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.cmpf ugt, %in, %cst_209 : f32
+      %363 = arith.select %362, %in, %cst_209 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x1024xf32>
+    %353 = linalg.generic {indexing_maps = [#map8, #map10, #map6], iterator_types = ["parallel", "parallel"]} ins(%352, %10 : tensor<1x1024xf32>, tensor<f32>) outs(%347 : tensor<1x1024xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.cmpf olt, %in, %in_238 : f32
+      %363 = arith.select %362, %in, %in_238 : f32
+      linalg.yield %363 : f32
+    } -> tensor<1x1024xf32>
+    %354 = linalg.generic {indexing_maps = [#map8, #map6], iterator_types = ["parallel", "parallel"]} ins(%353 : tensor<1x1024xf32>) outs(%347 : tensor<1x1024xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %362 = arith.divf %in, %cst_212 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x1024xf32>
+    %355 = linalg.generic {indexing_maps = [#map8, #map8, #map6], iterator_types = ["parallel", "parallel"]} ins(%354, %350 : tensor<1x1024xf32>, tensor<1x1024xf32>) outs(%347 : tensor<1x1024xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.mulf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x1024xf32>
+    %356 = tensor.empty() : tensor<1024x1000xf32>
+    %357 = linalg.generic {indexing_maps = [#map6, #map7], iterator_types = ["parallel", "parallel"]} ins(%cst_0 : tensor<1000x1024xf32>) outs(%356 : tensor<1024x1000xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1024x1000xf32>
+    %358 = tensor.empty() : tensor<1x1000xf32>
+    %359 = linalg.fill ins(%cst_209 : f32) outs(%358 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %360 = linalg.matmul ins(%355, %357 : tensor<1x1024xf32>, tensor<1024x1000xf32>) outs(%359 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %361 = linalg.generic {indexing_maps = [#map8, #map9, #map6], iterator_types = ["parallel", "parallel"]} ins(%360, %cst : tensor<1x1000xf32>, tensor<1000xf32>) outs(%358 : tensor<1x1000xf32>) {
+    ^bb0(%in: f32, %in_238: f32, %out: f32):
+      %362 = arith.addf %in, %in_238 : f32
+      linalg.yield %362 : f32
+    } -> tensor<1x1000xf32>
+    return %361 : tensor<1x1000xf32>
+  }
+}

--- a/mlir_outputs/resnet50.mlir
+++ b/mlir_outputs/resnet50.mlir
@@ -1,0 +1,1274 @@
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+#map4 = affine_map<(d0, d1) -> (d1, d0)>
+#map5 = affine_map<(d0, d1) -> (0, d1)>
+#map6 = affine_map<(d0, d1) -> (d1)>
+module attributes {torch.debug_module_name = "ResNet"} {
+  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
+  func.func @forward(%arg0: tensor<1x3x224x224xf32>) -> tensor<1x1000xf32> {
+    %cst = arith.constant dense_resource<__elided__> : tensor<1000xf32>
+    %cst_0 = arith.constant dense_resource<__elided__> : tensor<1000x2048xf32>
+    %cst_1 = arith.constant dense_resource<__elided__> : tensor<2048x512x1x1xf32>
+    %cst_2 = arith.constant dense_resource<__elided__> : tensor<512x512x3x3xf32>
+    %cst_3 = arith.constant dense_resource<__elided__> : tensor<512x2048x1x1xf32>
+    %cst_4 = arith.constant dense_resource<__elided__> : tensor<2048x512x1x1xf32>
+    %cst_5 = arith.constant dense_resource<__elided__> : tensor<512x512x3x3xf32>
+    %cst_6 = arith.constant dense_resource<__elided__> : tensor<512x2048x1x1xf32>
+    %cst_7 = arith.constant dense_resource<__elided__> : tensor<2048x1024x1x1xf32>
+    %cst_8 = arith.constant dense<1.000000e+00> : tensor<2048xf32>
+    %cst_9 = arith.constant dense<0.000000e+00> : tensor<2048xf32>
+    %cst_10 = arith.constant dense_resource<__elided__> : tensor<2048x512x1x1xf32>
+    %cst_11 = arith.constant dense_resource<__elided__> : tensor<512x512x3x3xf32>
+    %cst_12 = arith.constant dense_resource<__elided__> : tensor<512x1024x1x1xf32>
+    %cst_13 = arith.constant dense_resource<__elided__> : tensor<1024x256x1x1xf32>
+    %cst_14 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_15 = arith.constant dense_resource<__elided__> : tensor<256x1024x1x1xf32>
+    %cst_16 = arith.constant dense_resource<__elided__> : tensor<1024x256x1x1xf32>
+    %cst_17 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_18 = arith.constant dense_resource<__elided__> : tensor<256x1024x1x1xf32>
+    %cst_19 = arith.constant dense_resource<__elided__> : tensor<1024x256x1x1xf32>
+    %cst_20 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_21 = arith.constant dense_resource<__elided__> : tensor<256x1024x1x1xf32>
+    %cst_22 = arith.constant dense_resource<__elided__> : tensor<1024x256x1x1xf32>
+    %cst_23 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_24 = arith.constant dense_resource<__elided__> : tensor<256x1024x1x1xf32>
+    %cst_25 = arith.constant dense_resource<__elided__> : tensor<1024x256x1x1xf32>
+    %cst_26 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_27 = arith.constant dense_resource<__elided__> : tensor<256x1024x1x1xf32>
+    %cst_28 = arith.constant dense_resource<__elided__> : tensor<1024x512x1x1xf32>
+    %cst_29 = arith.constant dense<1.000000e+00> : tensor<1024xf32>
+    %cst_30 = arith.constant dense<0.000000e+00> : tensor<1024xf32>
+    %cst_31 = arith.constant dense_resource<__elided__> : tensor<1024x256x1x1xf32>
+    %cst_32 = arith.constant dense_resource<__elided__> : tensor<256x256x3x3xf32>
+    %cst_33 = arith.constant dense_resource<__elided__> : tensor<256x512x1x1xf32>
+    %cst_34 = arith.constant dense_resource<__elided__> : tensor<512x128x1x1xf32>
+    %cst_35 = arith.constant dense_resource<__elided__> : tensor<128x128x3x3xf32>
+    %cst_36 = arith.constant dense_resource<__elided__> : tensor<128x512x1x1xf32>
+    %cst_37 = arith.constant dense_resource<__elided__> : tensor<512x128x1x1xf32>
+    %cst_38 = arith.constant dense_resource<__elided__> : tensor<128x128x3x3xf32>
+    %cst_39 = arith.constant dense_resource<__elided__> : tensor<128x512x1x1xf32>
+    %cst_40 = arith.constant dense_resource<__elided__> : tensor<512x128x1x1xf32>
+    %cst_41 = arith.constant dense_resource<__elided__> : tensor<128x128x3x3xf32>
+    %cst_42 = arith.constant dense_resource<__elided__> : tensor<128x512x1x1xf32>
+    %cst_43 = arith.constant dense_resource<__elided__> : tensor<512x256x1x1xf32>
+    %cst_44 = arith.constant dense<1.000000e+00> : tensor<512xf32>
+    %cst_45 = arith.constant dense<0.000000e+00> : tensor<512xf32>
+    %cst_46 = arith.constant dense_resource<__elided__> : tensor<512x128x1x1xf32>
+    %cst_47 = arith.constant dense_resource<__elided__> : tensor<128x128x3x3xf32>
+    %cst_48 = arith.constant dense<1.000000e+00> : tensor<128xf32>
+    %cst_49 = arith.constant dense<0.000000e+00> : tensor<128xf32>
+    %cst_50 = arith.constant dense_resource<__elided__> : tensor<128x256x1x1xf32>
+    %cst_51 = arith.constant dense_resource<__elided__> : tensor<256x64x1x1xf32>
+    %cst_52 = arith.constant dense_resource<__elided__> : tensor<64x64x3x3xf32>
+    %cst_53 = arith.constant dense_resource<__elided__> : tensor<64x256x1x1xf32>
+    %cst_54 = arith.constant dense_resource<__elided__> : tensor<256x64x1x1xf32>
+    %cst_55 = arith.constant dense_resource<__elided__> : tensor<64x64x3x3xf32>
+    %cst_56 = arith.constant dense_resource<__elided__> : tensor<64x256x1x1xf32>
+    %cst_57 = arith.constant dense_resource<__elided__> : tensor<256x64x1x1xf32>
+    %cst_58 = arith.constant dense<1.000000e+00> : tensor<256xf32>
+    %cst_59 = arith.constant dense<0.000000e+00> : tensor<256xf32>
+    %cst_60 = arith.constant dense_resource<__elided__> : tensor<256x64x1x1xf32>
+    %cst_61 = arith.constant dense_resource<__elided__> : tensor<64x64x3x3xf32>
+    %cst_62 = arith.constant dense_resource<__elided__> : tensor<64x64x1x1xf32>
+    %cst_63 = arith.constant dense<1.000000e+00> : tensor<64xf32>
+    %cst_64 = arith.constant dense<0.000000e+00> : tensor<64xf32>
+    %cst_65 = arith.constant dense_resource<__elided__> : tensor<64x3x7x7xf32>
+    %false = arith.constant false
+    %cst_66 = arith.constant 0.000000e+00 : f32
+    %cst_67 = arith.constant 0xFF800000 : f32
+    %cst_68 = arith.constant 1.000000e-05 : f64
+    %c0 = arith.constant 0 : index
+    %c3 = arith.constant 3 : index
+    %c1 = arith.constant 1 : index
+    %cst_69 = arith.constant 4.900000e+01 : f32
+    %padded = tensor.pad %arg0 low[0, 0, 3, 3] high[0, 0, 3, 3] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x3x224x224xf32> to tensor<1x3x230x230xf32>
+    %0 = tensor.empty() : tensor<1x64x112x112xf32>
+    %1 = linalg.fill ins(%cst_66 : f32) outs(%0 : tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded, %cst_65 : tensor<1x3x230x230xf32>, tensor<64x3x7x7xf32>) outs(%1 : tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32>
+    %3 = arith.cmpi eq, %false, %false : i1
+    cf.assert %3, "training is not supported for now"
+    %4 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %cst_63, %cst_64, %cst_64, %cst_63 : tensor<1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%2 : tensor<1x64x112x112xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x64x112x112xf32>
+    %5 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4 : tensor<1x64x112x112xf32>) outs(%0 : tensor<1x64x112x112xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x64x112x112xf32>
+    %padded_70 = tensor.pad %5 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_67 : f32
+    } : tensor<1x64x112x112xf32> to tensor<1x64x114x114xf32>
+    %6 = tensor.empty() : tensor<1x64x56x56xf32>
+    %7 = linalg.fill ins(%cst_67 : f32) outs(%6 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %8 = tensor.empty() : tensor<3x3xf32>
+    %9 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_70, %8 : tensor<1x64x114x114xf32>, tensor<3x3xf32>) outs(%7 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %10 = linalg.fill ins(%cst_66 : f32) outs(%6 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %11 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%9, %cst_62 : tensor<1x64x56x56xf32>, tensor<64x64x1x1xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %12 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%11, %cst_63, %cst_64, %cst_64, %cst_63 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%11 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x64x56x56xf32>
+    %13 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%12 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x64x56x56xf32>
+    %padded_71 = tensor.pad %13 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %14 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_71, %cst_61 : tensor<1x64x58x58xf32>, tensor<64x64x3x3xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %15 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%14, %cst_63, %cst_64, %cst_64, %cst_63 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%14 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x64x56x56xf32>
+    %16 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%15 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x64x56x56xf32>
+    %17 = tensor.empty() : tensor<1x256x56x56xf32>
+    %18 = linalg.fill ins(%cst_66 : f32) outs(%17 : tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    %19 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%16, %cst_60 : tensor<1x64x56x56xf32>, tensor<256x64x1x1xf32>) outs(%18 : tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %20 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%19, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x56x56xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%19 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x56x56xf32>
+    %21 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%9, %cst_57 : tensor<1x64x56x56xf32>, tensor<256x64x1x1xf32>) outs(%18 : tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %22 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%21, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x56x56xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%21 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x56x56xf32>
+    %23 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%20, %22 : tensor<1x256x56x56xf32>, tensor<1x256x56x56xf32>) outs(%17 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x256x56x56xf32>
+    %24 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%23 : tensor<1x256x56x56xf32>) outs(%17 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x56x56xf32>
+    %25 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%24, %cst_56 : tensor<1x256x56x56xf32>, tensor<64x256x1x1xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %26 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%25, %cst_63, %cst_64, %cst_64, %cst_63 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%25 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x64x56x56xf32>
+    %27 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%26 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x64x56x56xf32>
+    %padded_72 = tensor.pad %27 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %28 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_72, %cst_55 : tensor<1x64x58x58xf32>, tensor<64x64x3x3xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %29 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%28, %cst_63, %cst_64, %cst_64, %cst_63 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%28 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x64x56x56xf32>
+    %30 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%29 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x64x56x56xf32>
+    %31 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%30, %cst_54 : tensor<1x64x56x56xf32>, tensor<256x64x1x1xf32>) outs(%18 : tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %32 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%31, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x56x56xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%31 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x56x56xf32>
+    %33 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%32, %24 : tensor<1x256x56x56xf32>, tensor<1x256x56x56xf32>) outs(%17 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x256x56x56xf32>
+    %34 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33 : tensor<1x256x56x56xf32>) outs(%17 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x56x56xf32>
+    %35 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%34, %cst_53 : tensor<1x256x56x56xf32>, tensor<64x256x1x1xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %36 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%35, %cst_63, %cst_64, %cst_64, %cst_63 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%35 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x64x56x56xf32>
+    %37 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x64x56x56xf32>
+    %padded_73 = tensor.pad %37 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x64x56x56xf32> to tensor<1x64x58x58xf32>
+    %38 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_73, %cst_52 : tensor<1x64x58x58xf32>, tensor<64x64x3x3xf32>) outs(%10 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %39 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%38, %cst_63, %cst_64, %cst_64, %cst_63 : tensor<1x64x56x56xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) outs(%38 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x64x56x56xf32>
+    %40 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%39 : tensor<1x64x56x56xf32>) outs(%6 : tensor<1x64x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x64x56x56xf32>
+    %41 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%40, %cst_51 : tensor<1x64x56x56xf32>, tensor<256x64x1x1xf32>) outs(%18 : tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %42 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%41, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x56x56xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%41 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x56x56xf32>
+    %43 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%42, %34 : tensor<1x256x56x56xf32>, tensor<1x256x56x56xf32>) outs(%17 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x256x56x56xf32>
+    %44 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%43 : tensor<1x256x56x56xf32>) outs(%17 : tensor<1x256x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x56x56xf32>
+    %45 = tensor.empty() : tensor<1x128x56x56xf32>
+    %46 = linalg.fill ins(%cst_66 : f32) outs(%45 : tensor<1x128x56x56xf32>) -> tensor<1x128x56x56xf32>
+    %47 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%44, %cst_50 : tensor<1x256x56x56xf32>, tensor<128x256x1x1xf32>) outs(%46 : tensor<1x128x56x56xf32>) -> tensor<1x128x56x56xf32>
+    cf.assert %3, "training is not supported for now"
+    %48 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%47, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x56x56xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%47 : tensor<1x128x56x56xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x56x56xf32>
+    %49 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%48 : tensor<1x128x56x56xf32>) outs(%45 : tensor<1x128x56x56xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x56x56xf32>
+    %padded_74 = tensor.pad %49 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x128x56x56xf32> to tensor<1x128x58x58xf32>
+    %50 = tensor.empty() : tensor<1x128x28x28xf32>
+    %51 = linalg.fill ins(%cst_66 : f32) outs(%50 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    %52 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_74, %cst_47 : tensor<1x128x58x58xf32>, tensor<128x128x3x3xf32>) outs(%51 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %53 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%52, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%52 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x28x28xf32>
+    %54 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%53 : tensor<1x128x28x28xf32>) outs(%50 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x28x28xf32>
+    %55 = tensor.empty() : tensor<1x512x28x28xf32>
+    %56 = linalg.fill ins(%cst_66 : f32) outs(%55 : tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    %57 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%54, %cst_46 : tensor<1x128x28x28xf32>, tensor<512x128x1x1xf32>) outs(%56 : tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %58 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%57, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x28x28xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%57 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x28x28xf32>
+    %59 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%44, %cst_43 : tensor<1x256x56x56xf32>, tensor<512x256x1x1xf32>) outs(%56 : tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %60 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%59, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x28x28xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%59 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x28x28xf32>
+    %61 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%58, %60 : tensor<1x512x28x28xf32>, tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x512x28x28xf32>
+    %62 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%61 : tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x28x28xf32>
+    %63 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%62, %cst_42 : tensor<1x512x28x28xf32>, tensor<128x512x1x1xf32>) outs(%51 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %64 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%63, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%63 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x28x28xf32>
+    %65 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%64 : tensor<1x128x28x28xf32>) outs(%50 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x28x28xf32>
+    %padded_75 = tensor.pad %65 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x128x28x28xf32> to tensor<1x128x30x30xf32>
+    %66 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_75, %cst_41 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%51 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %67 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%66, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%66 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x28x28xf32>
+    %68 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%67 : tensor<1x128x28x28xf32>) outs(%50 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x28x28xf32>
+    %69 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%68, %cst_40 : tensor<1x128x28x28xf32>, tensor<512x128x1x1xf32>) outs(%56 : tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %70 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%69, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x28x28xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%69 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x28x28xf32>
+    %71 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%70, %62 : tensor<1x512x28x28xf32>, tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x512x28x28xf32>
+    %72 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%71 : tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x28x28xf32>
+    %73 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%72, %cst_39 : tensor<1x512x28x28xf32>, tensor<128x512x1x1xf32>) outs(%51 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %74 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%73, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%73 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x28x28xf32>
+    %75 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%74 : tensor<1x128x28x28xf32>) outs(%50 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x28x28xf32>
+    %padded_76 = tensor.pad %75 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x128x28x28xf32> to tensor<1x128x30x30xf32>
+    %76 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_76, %cst_38 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%51 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %77 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%76, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%76 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x28x28xf32>
+    %78 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%77 : tensor<1x128x28x28xf32>) outs(%50 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x28x28xf32>
+    %79 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%78, %cst_37 : tensor<1x128x28x28xf32>, tensor<512x128x1x1xf32>) outs(%56 : tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %80 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%79, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x28x28xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%79 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x28x28xf32>
+    %81 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%80, %72 : tensor<1x512x28x28xf32>, tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x512x28x28xf32>
+    %82 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%81 : tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x28x28xf32>
+    %83 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%82, %cst_36 : tensor<1x512x28x28xf32>, tensor<128x512x1x1xf32>) outs(%51 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %84 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%83, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%83 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x28x28xf32>
+    %85 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%84 : tensor<1x128x28x28xf32>) outs(%50 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x28x28xf32>
+    %padded_77 = tensor.pad %85 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x128x28x28xf32> to tensor<1x128x30x30xf32>
+    %86 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_77, %cst_35 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%51 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %87 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%86, %cst_48, %cst_49, %cst_49, %cst_48 : tensor<1x128x28x28xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) outs(%86 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x128x28x28xf32>
+    %88 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%87 : tensor<1x128x28x28xf32>) outs(%50 : tensor<1x128x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x128x28x28xf32>
+    %89 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%88, %cst_34 : tensor<1x128x28x28xf32>, tensor<512x128x1x1xf32>) outs(%56 : tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %90 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%89, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x28x28xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%89 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x28x28xf32>
+    %91 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%90, %82 : tensor<1x512x28x28xf32>, tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x512x28x28xf32>
+    %92 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%91 : tensor<1x512x28x28xf32>) outs(%55 : tensor<1x512x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x28x28xf32>
+    %93 = tensor.empty() : tensor<1x256x28x28xf32>
+    %94 = linalg.fill ins(%cst_66 : f32) outs(%93 : tensor<1x256x28x28xf32>) -> tensor<1x256x28x28xf32>
+    %95 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%92, %cst_33 : tensor<1x512x28x28xf32>, tensor<256x512x1x1xf32>) outs(%94 : tensor<1x256x28x28xf32>) -> tensor<1x256x28x28xf32>
+    cf.assert %3, "training is not supported for now"
+    %96 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%95, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x28x28xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%95 : tensor<1x256x28x28xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x28x28xf32>
+    %97 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%96 : tensor<1x256x28x28xf32>) outs(%93 : tensor<1x256x28x28xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x28x28xf32>
+    %padded_78 = tensor.pad %97 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x256x28x28xf32> to tensor<1x256x30x30xf32>
+    %98 = tensor.empty() : tensor<1x256x14x14xf32>
+    %99 = linalg.fill ins(%cst_66 : f32) outs(%98 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    %100 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_78, %cst_32 : tensor<1x256x30x30xf32>, tensor<256x256x3x3xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %101 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%100, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%100 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %102 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%101 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %103 = tensor.empty() : tensor<1x1024x14x14xf32>
+    %104 = linalg.fill ins(%cst_66 : f32) outs(%103 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    %105 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%102, %cst_31 : tensor<1x256x14x14xf32>, tensor<1024x256x1x1xf32>) outs(%104 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %106 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%105, %cst_29, %cst_30, %cst_30, %cst_29 : tensor<1x1024x14x14xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%105 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %107 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%92, %cst_28 : tensor<1x512x28x28xf32>, tensor<1024x512x1x1xf32>) outs(%104 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %108 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%107, %cst_29, %cst_30, %cst_30, %cst_29 : tensor<1x1024x14x14xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%107 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %109 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%106, %108 : tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %110 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%109 : tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %111 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%110, %cst_27 : tensor<1x1024x14x14xf32>, tensor<256x1024x1x1xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %112 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%111, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%111 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %113 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%112 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_79 = tensor.pad %113 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %114 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_79, %cst_26 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %115 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%114, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%114 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %116 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%115 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %117 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%116, %cst_25 : tensor<1x256x14x14xf32>, tensor<1024x256x1x1xf32>) outs(%104 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %118 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%117, %cst_29, %cst_30, %cst_30, %cst_29 : tensor<1x1024x14x14xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%117 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %119 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%118, %110 : tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %120 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%119 : tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %121 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%120, %cst_24 : tensor<1x1024x14x14xf32>, tensor<256x1024x1x1xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %122 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%121, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%121 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %123 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%122 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_80 = tensor.pad %123 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %124 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_80, %cst_23 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %125 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%124, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%124 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %126 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%125 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %127 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%126, %cst_22 : tensor<1x256x14x14xf32>, tensor<1024x256x1x1xf32>) outs(%104 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %128 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%127, %cst_29, %cst_30, %cst_30, %cst_29 : tensor<1x1024x14x14xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%127 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %129 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%128, %120 : tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %130 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%129 : tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %131 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%130, %cst_21 : tensor<1x1024x14x14xf32>, tensor<256x1024x1x1xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %132 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%131, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%131 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %133 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%132 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_81 = tensor.pad %133 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %134 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_81, %cst_20 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %135 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%134, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%134 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %136 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%135 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %137 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%136, %cst_19 : tensor<1x256x14x14xf32>, tensor<1024x256x1x1xf32>) outs(%104 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %138 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%137, %cst_29, %cst_30, %cst_30, %cst_29 : tensor<1x1024x14x14xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%137 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %139 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%138, %130 : tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %140 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%139 : tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %141 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%140, %cst_18 : tensor<1x1024x14x14xf32>, tensor<256x1024x1x1xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %142 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%141, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%141 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %143 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%142 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_82 = tensor.pad %143 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %144 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_82, %cst_17 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %145 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%144, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%144 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %146 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%145 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %147 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%146, %cst_16 : tensor<1x256x14x14xf32>, tensor<1024x256x1x1xf32>) outs(%104 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %148 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%147, %cst_29, %cst_30, %cst_30, %cst_29 : tensor<1x1024x14x14xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%147 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %149 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%148, %140 : tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %150 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%149 : tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %151 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%150, %cst_15 : tensor<1x1024x14x14xf32>, tensor<256x1024x1x1xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %152 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%151, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%151 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %153 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%152 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %padded_83 = tensor.pad %153 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x256x14x14xf32> to tensor<1x256x16x16xf32>
+    %154 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_83, %cst_14 : tensor<1x256x16x16xf32>, tensor<256x256x3x3xf32>) outs(%99 : tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %155 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%154, %cst_58, %cst_59, %cst_59, %cst_58 : tensor<1x256x14x14xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) outs(%154 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x256x14x14xf32>
+    %156 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%155 : tensor<1x256x14x14xf32>) outs(%98 : tensor<1x256x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x256x14x14xf32>
+    %157 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%156, %cst_13 : tensor<1x256x14x14xf32>, tensor<1024x256x1x1xf32>) outs(%104 : tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %158 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%157, %cst_29, %cst_30, %cst_30, %cst_29 : tensor<1x1024x14x14xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%157 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %159 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%158, %150 : tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %160 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%159 : tensor<1x1024x14x14xf32>) outs(%103 : tensor<1x1024x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x1024x14x14xf32>
+    %161 = tensor.empty() : tensor<1x512x14x14xf32>
+    %162 = linalg.fill ins(%cst_66 : f32) outs(%161 : tensor<1x512x14x14xf32>) -> tensor<1x512x14x14xf32>
+    %163 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%160, %cst_12 : tensor<1x1024x14x14xf32>, tensor<512x1024x1x1xf32>) outs(%162 : tensor<1x512x14x14xf32>) -> tensor<1x512x14x14xf32>
+    cf.assert %3, "training is not supported for now"
+    %164 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%163, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x14x14xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%163 : tensor<1x512x14x14xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x14x14xf32>
+    %165 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%164 : tensor<1x512x14x14xf32>) outs(%161 : tensor<1x512x14x14xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x14x14xf32>
+    %padded_84 = tensor.pad %165 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x512x14x14xf32> to tensor<1x512x16x16xf32>
+    %166 = tensor.empty() : tensor<1x512x7x7xf32>
+    %167 = linalg.fill ins(%cst_66 : f32) outs(%166 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    %168 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_84, %cst_11 : tensor<1x512x16x16xf32>, tensor<512x512x3x3xf32>) outs(%167 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %169 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%168, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%168 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x7x7xf32>
+    %170 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%169 : tensor<1x512x7x7xf32>) outs(%166 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x7x7xf32>
+    %171 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %172 = linalg.fill ins(%cst_66 : f32) outs(%171 : tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %173 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%170, %cst_10 : tensor<1x512x7x7xf32>, tensor<2048x512x1x1xf32>) outs(%172 : tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %174 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%173, %cst_8, %cst_9, %cst_9, %cst_8 : tensor<1x2048x7x7xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>) outs(%173 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %175 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%160, %cst_7 : tensor<1x1024x14x14xf32>, tensor<2048x1024x1x1xf32>) outs(%172 : tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %176 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%175, %cst_8, %cst_9, %cst_9, %cst_8 : tensor<1x2048x7x7xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>) outs(%175 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %177 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%174, %176 : tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) outs(%171 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %178 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%177 : tensor<1x2048x7x7xf32>) outs(%171 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %179 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%178, %cst_6 : tensor<1x2048x7x7xf32>, tensor<512x2048x1x1xf32>) outs(%167 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %180 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%179, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%179 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x7x7xf32>
+    %181 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%180 : tensor<1x512x7x7xf32>) outs(%166 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x7x7xf32>
+    %padded_85 = tensor.pad %181 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x512x7x7xf32> to tensor<1x512x9x9xf32>
+    %182 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_85, %cst_5 : tensor<1x512x9x9xf32>, tensor<512x512x3x3xf32>) outs(%167 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %183 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%182, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%182 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x7x7xf32>
+    %184 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%183 : tensor<1x512x7x7xf32>) outs(%166 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x7x7xf32>
+    %185 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%184, %cst_4 : tensor<1x512x7x7xf32>, tensor<2048x512x1x1xf32>) outs(%172 : tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %186 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%185, %cst_8, %cst_9, %cst_9, %cst_8 : tensor<1x2048x7x7xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>) outs(%185 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %187 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%186, %178 : tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) outs(%171 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %188 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%187 : tensor<1x2048x7x7xf32>) outs(%171 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %189 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%188, %cst_3 : tensor<1x2048x7x7xf32>, tensor<512x2048x1x1xf32>) outs(%167 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %190 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%189, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%189 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x7x7xf32>
+    %191 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%190 : tensor<1x512x7x7xf32>) outs(%166 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x7x7xf32>
+    %padded_86 = tensor.pad %191 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_66 : f32
+    } : tensor<1x512x7x7xf32> to tensor<1x512x9x9xf32>
+    %192 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_86, %cst_2 : tensor<1x512x9x9xf32>, tensor<512x512x3x3xf32>) outs(%167 : tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %193 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%192, %cst_44, %cst_45, %cst_45, %cst_44 : tensor<1x512x7x7xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>, tensor<512xf32>) outs(%192 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x512x7x7xf32>
+    %194 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%193 : tensor<1x512x7x7xf32>) outs(%166 : tensor<1x512x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x512x7x7xf32>
+    %195 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%194, %cst_1 : tensor<1x512x7x7xf32>, tensor<2048x512x1x1xf32>) outs(%172 : tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    cf.assert %3, "training is not supported for now"
+    %196 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%195, %cst_8, %cst_9, %cst_9, %cst_8 : tensor<1x2048x7x7xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>, tensor<2048xf32>) outs(%195 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %in_88: f32, %in_89: f32, %in_90: f32, %out: f32):
+      %210 = arith.truncf %cst_68 : f64 to f32
+      %211 = arith.addf %in_90, %210 : f32
+      %212 = math.rsqrt %211 : f32
+      %213 = arith.subf %in, %in_89 : f32
+      %214 = arith.mulf %213, %212 : f32
+      %215 = arith.mulf %214, %in_87 : f32
+      %216 = arith.addf %215, %in_88 : f32
+      linalg.yield %216 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %197 = linalg.generic {indexing_maps = [#map2, #map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%196, %188 : tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) outs(%171 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %198 = linalg.generic {indexing_maps = [#map2, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%197 : tensor<1x2048x7x7xf32>) outs(%171 : tensor<1x2048x7x7xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.cmpf ugt, %in, %cst_66 : f32
+      %211 = arith.select %210, %in, %cst_66 : f32
+      linalg.yield %211 : f32
+    } -> tensor<1x2048x7x7xf32>
+    %199 = tensor.empty() : tensor<1x2048x1x1xf32>
+    %200 = linalg.fill ins(%cst_66 : f32) outs(%199 : tensor<1x2048x1x1xf32>) -> tensor<1x2048x1x1xf32>
+    %201 = tensor.empty() : tensor<7x7xf32>
+    %202 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%198, %201 : tensor<1x2048x7x7xf32>, tensor<7x7xf32>) outs(%200 : tensor<1x2048x1x1xf32>) -> tensor<1x2048x1x1xf32>
+    %203 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%202 : tensor<1x2048x1x1xf32>) outs(%199 : tensor<1x2048x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %210 = arith.divf %in, %cst_69 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x2048x1x1xf32>
+    %collapsed = tensor.collapse_shape %203 [[0], [1, 2, 3]] : tensor<1x2048x1x1xf32> into tensor<1x2048xf32>
+    %204 = tensor.empty() : tensor<2048x1000xf32>
+    %205 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel"]} ins(%cst_0 : tensor<1000x2048xf32>) outs(%204 : tensor<2048x1000xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<2048x1000xf32>
+    %206 = tensor.empty() : tensor<1x1000xf32>
+    %207 = linalg.fill ins(%cst_66 : f32) outs(%206 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %208 = linalg.matmul ins(%collapsed, %205 : tensor<1x2048xf32>, tensor<2048x1000xf32>) outs(%207 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %209 = linalg.generic {indexing_maps = [#map5, #map6, #map3], iterator_types = ["parallel", "parallel"]} ins(%208, %cst : tensor<1x1000xf32>, tensor<1000xf32>) outs(%206 : tensor<1x1000xf32>) {
+    ^bb0(%in: f32, %in_87: f32, %out: f32):
+      %210 = arith.addf %in, %in_87 : f32
+      linalg.yield %210 : f32
+    } -> tensor<1x1000xf32>
+    return %209 : tensor<1x1000xf32>
+  }
+}

--- a/mlir_outputs/squeezenet1_1.mlir
+++ b/mlir_outputs/squeezenet1_1.mlir
@@ -1,0 +1,349 @@
+#map = affine_map<(d0, d1, d2, d3) -> (d1)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>
+module attributes {torch.debug_module_name = "SqueezeNet"} {
+  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
+  func.func @forward(%arg0: tensor<1x3x224x224xf32>) -> tensor<1x1000xf32> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<1000xf32>
+    %cst_0 = arith.constant dense_resource<__elided__> : tensor<1000x512x1x1xf32>
+    %cst_1 = arith.constant dense_resource<__elided__> : tensor<256x64x3x3xf32>
+    %cst_2 = arith.constant dense_resource<__elided__> : tensor<256x64x1x1xf32>
+    %cst_3 = arith.constant dense_resource<__elided__> : tensor<64x512x1x1xf32>
+    %cst_4 = arith.constant dense_resource<__elided__> : tensor<256x64x3x3xf32>
+    %cst_5 = arith.constant dense<0.000000e+00> : tensor<256xf32>
+    %cst_6 = arith.constant dense_resource<__elided__> : tensor<256x64x1x1xf32>
+    %cst_7 = arith.constant dense_resource<__elided__> : tensor<64x384x1x1xf32>
+    %cst_8 = arith.constant dense_resource<__elided__> : tensor<192x48x3x3xf32>
+    %cst_9 = arith.constant dense_resource<__elided__> : tensor<192x48x1x1xf32>
+    %cst_10 = arith.constant dense_resource<__elided__> : tensor<48x384x1x1xf32>
+    %cst_11 = arith.constant dense_resource<__elided__> : tensor<192x48x3x3xf32>
+    %cst_12 = arith.constant dense<0.000000e+00> : tensor<192xf32>
+    %cst_13 = arith.constant dense_resource<__elided__> : tensor<192x48x1x1xf32>
+    %cst_14 = arith.constant dense<0.000000e+00> : tensor<48xf32>
+    %cst_15 = arith.constant dense_resource<__elided__> : tensor<48x256x1x1xf32>
+    %cst_16 = arith.constant dense_resource<__elided__> : tensor<128x32x3x3xf32>
+    %cst_17 = arith.constant dense_resource<__elided__> : tensor<128x32x1x1xf32>
+    %cst_18 = arith.constant dense_resource<__elided__> : tensor<32x256x1x1xf32>
+    %cst_19 = arith.constant dense_resource<__elided__> : tensor<128x32x3x3xf32>
+    %cst_20 = arith.constant dense<0.000000e+00> : tensor<128xf32>
+    %cst_21 = arith.constant dense_resource<__elided__> : tensor<128x32x1x1xf32>
+    %cst_22 = arith.constant dense<0.000000e+00> : tensor<32xf32>
+    %cst_23 = arith.constant dense_resource<__elided__> : tensor<32x128x1x1xf32>
+    %cst_24 = arith.constant dense_resource<__elided__> : tensor<64x16x3x3xf32>
+    %cst_25 = arith.constant dense_resource<__elided__> : tensor<64x16x1x1xf32>
+    %cst_26 = arith.constant dense_resource<__elided__> : tensor<16x128x1x1xf32>
+    %cst_27 = arith.constant dense_resource<__elided__> : tensor<64x16x3x3xf32>
+    %cst_28 = arith.constant dense_resource<__elided__> : tensor<64x16x1x1xf32>
+    %cst_29 = arith.constant dense<0.000000e+00> : tensor<16xf32>
+    %cst_30 = arith.constant dense_resource<__elided__> : tensor<16x64x1x1xf32>
+    %cst_31 = arith.constant dense<0.000000e+00> : tensor<64xf32>
+    %cst_32 = arith.constant dense_resource<__elided__> : tensor<64x3x3x3xf32>
+    %cst_33 = arith.constant 0.000000e+00 : f32
+    %cst_34 = arith.constant 0xFF800000 : f32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cst_35 = arith.constant 1.690000e+02 : f32
+    %0 = tensor.empty() : tensor<1x64x111x111xf32>
+    %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_31 : tensor<64xf32>) outs(%0 : tensor<1x64x111x111xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x64x111x111xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%arg0, %cst_32 : tensor<1x3x224x224xf32>, tensor<64x3x3x3xf32>) outs(%1 : tensor<1x64x111x111xf32>) -> tensor<1x64x111x111xf32>
+    %3 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<1x64x111x111xf32>) outs(%0 : tensor<1x64x111x111xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x64x111x111xf32>
+    %padded = tensor.pad %3 low[0, 0, 0, 0] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_34 : f32
+    } : tensor<1x64x111x111xf32> to tensor<1x64x113x113xf32>
+    %4 = tensor.empty() : tensor<1x64x55x55xf32>
+    %5 = linalg.fill ins(%cst_34 : f32) outs(%4 : tensor<1x64x55x55xf32>) -> tensor<1x64x55x55xf32>
+    %6 = tensor.empty() : tensor<3x3xf32>
+    %7 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded, %6 : tensor<1x64x113x113xf32>, tensor<3x3xf32>) outs(%5 : tensor<1x64x55x55xf32>) -> tensor<1x64x55x55xf32>
+    %8 = tensor.empty() : tensor<1x16x55x55xf32>
+    %9 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_29 : tensor<16xf32>) outs(%8 : tensor<1x16x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x16x55x55xf32>
+    %10 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%7, %cst_30 : tensor<1x64x55x55xf32>, tensor<16x64x1x1xf32>) outs(%9 : tensor<1x16x55x55xf32>) -> tensor<1x16x55x55xf32>
+    %11 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10 : tensor<1x16x55x55xf32>) outs(%8 : tensor<1x16x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x16x55x55xf32>
+    %12 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_31 : tensor<64xf32>) outs(%4 : tensor<1x64x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x64x55x55xf32>
+    %13 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%11, %cst_28 : tensor<1x16x55x55xf32>, tensor<64x16x1x1xf32>) outs(%12 : tensor<1x64x55x55xf32>) -> tensor<1x64x55x55xf32>
+    %14 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%13 : tensor<1x64x55x55xf32>) outs(%4 : tensor<1x64x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x64x55x55xf32>
+    %padded_36 = tensor.pad %11 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x16x55x55xf32> to tensor<1x16x57x57xf32>
+    %15 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_36, %cst_27 : tensor<1x16x57x57xf32>, tensor<64x16x3x3xf32>) outs(%12 : tensor<1x64x55x55xf32>) -> tensor<1x64x55x55xf32>
+    %16 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%15 : tensor<1x64x55x55xf32>) outs(%4 : tensor<1x64x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x64x55x55xf32>
+    %concat = tensor.concat dim(1) %14, %16 : (tensor<1x64x55x55xf32>, tensor<1x64x55x55xf32>) -> tensor<1x128x55x55xf32>
+    %17 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%concat, %cst_26 : tensor<1x128x55x55xf32>, tensor<16x128x1x1xf32>) outs(%9 : tensor<1x16x55x55xf32>) -> tensor<1x16x55x55xf32>
+    %18 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%17 : tensor<1x16x55x55xf32>) outs(%8 : tensor<1x16x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x16x55x55xf32>
+    %19 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%18, %cst_25 : tensor<1x16x55x55xf32>, tensor<64x16x1x1xf32>) outs(%12 : tensor<1x64x55x55xf32>) -> tensor<1x64x55x55xf32>
+    %20 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%19 : tensor<1x64x55x55xf32>) outs(%4 : tensor<1x64x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x64x55x55xf32>
+    %padded_37 = tensor.pad %18 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x16x55x55xf32> to tensor<1x16x57x57xf32>
+    %21 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_37, %cst_24 : tensor<1x16x57x57xf32>, tensor<64x16x3x3xf32>) outs(%12 : tensor<1x64x55x55xf32>) -> tensor<1x64x55x55xf32>
+    %22 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%21 : tensor<1x64x55x55xf32>) outs(%4 : tensor<1x64x55x55xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x64x55x55xf32>
+    %concat_38 = tensor.concat dim(1) %20, %22 : (tensor<1x64x55x55xf32>, tensor<1x64x55x55xf32>) -> tensor<1x128x55x55xf32>
+    %padded_39 = tensor.pad %concat_38 low[0, 0, 0, 0] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_34 : f32
+    } : tensor<1x128x55x55xf32> to tensor<1x128x57x57xf32>
+    %23 = tensor.empty() : tensor<1x128x27x27xf32>
+    %24 = linalg.fill ins(%cst_34 : f32) outs(%23 : tensor<1x128x27x27xf32>) -> tensor<1x128x27x27xf32>
+    %25 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_39, %6 : tensor<1x128x57x57xf32>, tensor<3x3xf32>) outs(%24 : tensor<1x128x27x27xf32>) -> tensor<1x128x27x27xf32>
+    %26 = tensor.empty() : tensor<1x32x27x27xf32>
+    %27 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_22 : tensor<32xf32>) outs(%26 : tensor<1x32x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x32x27x27xf32>
+    %28 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%25, %cst_23 : tensor<1x128x27x27xf32>, tensor<32x128x1x1xf32>) outs(%27 : tensor<1x32x27x27xf32>) -> tensor<1x32x27x27xf32>
+    %29 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%28 : tensor<1x32x27x27xf32>) outs(%26 : tensor<1x32x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x32x27x27xf32>
+    %30 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_20 : tensor<128xf32>) outs(%23 : tensor<1x128x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x128x27x27xf32>
+    %31 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%29, %cst_21 : tensor<1x32x27x27xf32>, tensor<128x32x1x1xf32>) outs(%30 : tensor<1x128x27x27xf32>) -> tensor<1x128x27x27xf32>
+    %32 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%31 : tensor<1x128x27x27xf32>) outs(%23 : tensor<1x128x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x128x27x27xf32>
+    %padded_40 = tensor.pad %29 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x32x27x27xf32> to tensor<1x32x29x29xf32>
+    %33 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_40, %cst_19 : tensor<1x32x29x29xf32>, tensor<128x32x3x3xf32>) outs(%30 : tensor<1x128x27x27xf32>) -> tensor<1x128x27x27xf32>
+    %34 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%33 : tensor<1x128x27x27xf32>) outs(%23 : tensor<1x128x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x128x27x27xf32>
+    %concat_41 = tensor.concat dim(1) %32, %34 : (tensor<1x128x27x27xf32>, tensor<1x128x27x27xf32>) -> tensor<1x256x27x27xf32>
+    %35 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%concat_41, %cst_18 : tensor<1x256x27x27xf32>, tensor<32x256x1x1xf32>) outs(%27 : tensor<1x32x27x27xf32>) -> tensor<1x32x27x27xf32>
+    %36 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%35 : tensor<1x32x27x27xf32>) outs(%26 : tensor<1x32x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x32x27x27xf32>
+    %37 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%36, %cst_17 : tensor<1x32x27x27xf32>, tensor<128x32x1x1xf32>) outs(%30 : tensor<1x128x27x27xf32>) -> tensor<1x128x27x27xf32>
+    %38 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%37 : tensor<1x128x27x27xf32>) outs(%23 : tensor<1x128x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x128x27x27xf32>
+    %padded_42 = tensor.pad %36 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x32x27x27xf32> to tensor<1x32x29x29xf32>
+    %39 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_42, %cst_16 : tensor<1x32x29x29xf32>, tensor<128x32x3x3xf32>) outs(%30 : tensor<1x128x27x27xf32>) -> tensor<1x128x27x27xf32>
+    %40 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%39 : tensor<1x128x27x27xf32>) outs(%23 : tensor<1x128x27x27xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x128x27x27xf32>
+    %concat_43 = tensor.concat dim(1) %38, %40 : (tensor<1x128x27x27xf32>, tensor<1x128x27x27xf32>) -> tensor<1x256x27x27xf32>
+    %padded_44 = tensor.pad %concat_43 low[0, 0, 0, 0] high[0, 0, 2, 2] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_34 : f32
+    } : tensor<1x256x27x27xf32> to tensor<1x256x29x29xf32>
+    %41 = tensor.empty() : tensor<1x256x13x13xf32>
+    %42 = linalg.fill ins(%cst_34 : f32) outs(%41 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %43 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%padded_44, %6 : tensor<1x256x29x29xf32>, tensor<3x3xf32>) outs(%42 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %44 = tensor.empty() : tensor<1x48x13x13xf32>
+    %45 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_14 : tensor<48xf32>) outs(%44 : tensor<1x48x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x48x13x13xf32>
+    %46 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%43, %cst_15 : tensor<1x256x13x13xf32>, tensor<48x256x1x1xf32>) outs(%45 : tensor<1x48x13x13xf32>) -> tensor<1x48x13x13xf32>
+    %47 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%46 : tensor<1x48x13x13xf32>) outs(%44 : tensor<1x48x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x48x13x13xf32>
+    %48 = tensor.empty() : tensor<1x192x13x13xf32>
+    %49 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_12 : tensor<192xf32>) outs(%48 : tensor<1x192x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x192x13x13xf32>
+    %50 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%47, %cst_13 : tensor<1x48x13x13xf32>, tensor<192x48x1x1xf32>) outs(%49 : tensor<1x192x13x13xf32>) -> tensor<1x192x13x13xf32>
+    %51 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%50 : tensor<1x192x13x13xf32>) outs(%48 : tensor<1x192x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x192x13x13xf32>
+    %padded_45 = tensor.pad %47 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x48x13x13xf32> to tensor<1x48x15x15xf32>
+    %52 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_45, %cst_11 : tensor<1x48x15x15xf32>, tensor<192x48x3x3xf32>) outs(%49 : tensor<1x192x13x13xf32>) -> tensor<1x192x13x13xf32>
+    %53 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%52 : tensor<1x192x13x13xf32>) outs(%48 : tensor<1x192x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x192x13x13xf32>
+    %concat_46 = tensor.concat dim(1) %51, %53 : (tensor<1x192x13x13xf32>, tensor<1x192x13x13xf32>) -> tensor<1x384x13x13xf32>
+    %54 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%concat_46, %cst_10 : tensor<1x384x13x13xf32>, tensor<48x384x1x1xf32>) outs(%45 : tensor<1x48x13x13xf32>) -> tensor<1x48x13x13xf32>
+    %55 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%54 : tensor<1x48x13x13xf32>) outs(%44 : tensor<1x48x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x48x13x13xf32>
+    %56 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%55, %cst_9 : tensor<1x48x13x13xf32>, tensor<192x48x1x1xf32>) outs(%49 : tensor<1x192x13x13xf32>) -> tensor<1x192x13x13xf32>
+    %57 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%56 : tensor<1x192x13x13xf32>) outs(%48 : tensor<1x192x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x192x13x13xf32>
+    %padded_47 = tensor.pad %55 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x48x13x13xf32> to tensor<1x48x15x15xf32>
+    %58 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_47, %cst_8 : tensor<1x48x15x15xf32>, tensor<192x48x3x3xf32>) outs(%49 : tensor<1x192x13x13xf32>) -> tensor<1x192x13x13xf32>
+    %59 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%58 : tensor<1x192x13x13xf32>) outs(%48 : tensor<1x192x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x192x13x13xf32>
+    %concat_48 = tensor.concat dim(1) %57, %59 : (tensor<1x192x13x13xf32>, tensor<1x192x13x13xf32>) -> tensor<1x384x13x13xf32>
+    %60 = tensor.empty() : tensor<1x64x13x13xf32>
+    %61 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_31 : tensor<64xf32>) outs(%60 : tensor<1x64x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x64x13x13xf32>
+    %62 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%concat_48, %cst_7 : tensor<1x384x13x13xf32>, tensor<64x384x1x1xf32>) outs(%61 : tensor<1x64x13x13xf32>) -> tensor<1x64x13x13xf32>
+    %63 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%62 : tensor<1x64x13x13xf32>) outs(%60 : tensor<1x64x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x64x13x13xf32>
+    %64 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_5 : tensor<256xf32>) outs(%41 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x256x13x13xf32>
+    %65 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%63, %cst_6 : tensor<1x64x13x13xf32>, tensor<256x64x1x1xf32>) outs(%64 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %66 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%65 : tensor<1x256x13x13xf32>) outs(%41 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x256x13x13xf32>
+    %padded_49 = tensor.pad %63 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x64x13x13xf32> to tensor<1x64x15x15xf32>
+    %67 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_49, %cst_4 : tensor<1x64x15x15xf32>, tensor<256x64x3x3xf32>) outs(%64 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %68 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%67 : tensor<1x256x13x13xf32>) outs(%41 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x256x13x13xf32>
+    %concat_50 = tensor.concat dim(1) %66, %68 : (tensor<1x256x13x13xf32>, tensor<1x256x13x13xf32>) -> tensor<1x512x13x13xf32>
+    %69 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%concat_50, %cst_3 : tensor<1x512x13x13xf32>, tensor<64x512x1x1xf32>) outs(%61 : tensor<1x64x13x13xf32>) -> tensor<1x64x13x13xf32>
+    %70 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%69 : tensor<1x64x13x13xf32>) outs(%60 : tensor<1x64x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x64x13x13xf32>
+    %71 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%70, %cst_2 : tensor<1x64x13x13xf32>, tensor<256x64x1x1xf32>) outs(%64 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %72 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%71 : tensor<1x256x13x13xf32>) outs(%41 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x256x13x13xf32>
+    %padded_51 = tensor.pad %70 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+    ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      tensor.yield %cst_33 : f32
+    } : tensor<1x64x13x13xf32> to tensor<1x64x15x15xf32>
+    %73 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded_51, %cst_1 : tensor<1x64x15x15xf32>, tensor<256x64x3x3xf32>) outs(%64 : tensor<1x256x13x13xf32>) -> tensor<1x256x13x13xf32>
+    %74 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%73 : tensor<1x256x13x13xf32>) outs(%41 : tensor<1x256x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x256x13x13xf32>
+    %concat_52 = tensor.concat dim(1) %72, %74 : (tensor<1x256x13x13xf32>, tensor<1x256x13x13xf32>) -> tensor<1x512x13x13xf32>
+    %75 = tensor.empty() : tensor<1x1000x13x13xf32>
+    %76 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst : tensor<1000xf32>) outs(%75 : tensor<1x1000x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<1x1000x13x13xf32>
+    %77 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%concat_52, %cst_0 : tensor<1x512x13x13xf32>, tensor<1000x512x1x1xf32>) outs(%76 : tensor<1x1000x13x13xf32>) -> tensor<1x1000x13x13xf32>
+    %78 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%77 : tensor<1x1000x13x13xf32>) outs(%75 : tensor<1x1000x13x13xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.cmpf ugt, %in, %cst_33 : f32
+      %85 = arith.select %84, %in, %cst_33 : f32
+      linalg.yield %85 : f32
+    } -> tensor<1x1000x13x13xf32>
+    %79 = tensor.empty() : tensor<1x1000x1x1xf32>
+    %80 = linalg.fill ins(%cst_33 : f32) outs(%79 : tensor<1x1000x1x1xf32>) -> tensor<1x1000x1x1xf32>
+    %81 = tensor.empty() : tensor<13x13xf32>
+    %82 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%78, %81 : tensor<1x1000x13x13xf32>, tensor<13x13xf32>) outs(%80 : tensor<1x1000x1x1xf32>) -> tensor<1x1000x1x1xf32>
+    %83 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%82 : tensor<1x1000x1x1xf32>) outs(%79 : tensor<1x1000x1x1xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %84 = arith.divf %in, %cst_35 : f32
+      linalg.yield %84 : f32
+    } -> tensor<1x1000x1x1xf32>
+    %collapsed = tensor.collapse_shape %83 [[0], [1, 2, 3]] : tensor<1x1000x1x1xf32> into tensor<1x1000xf32>
+    return %collapsed : tensor<1x1000xf32>
+  }
+}

--- a/scripts/resnet18_to_mlir.py
+++ b/scripts/resnet18_to_mlir.py
@@ -1,14 +1,15 @@
-"""Utility to compile a ResNet-18 model to MLIR using torch-mlir.
+"""Utility to compile torchvision models to MLIR using torch-mlir.
 
-This script builds a ResNet-18 network in PyTorch and lowers it to the
-``linalg-on-tensors`` dialect with :mod:`torch_mlir`.  It is intended to be a
-minimal, dependency-light example of using torch-mlir for model conversion.
+This script builds a classification model from :mod:`torchvision.models` and
+lowers it to the ``linalg-on-tensors`` dialect with :mod:`torch_mlir`.  It is
+intended to be a minimal example of using torch-mlir for model conversion.
 """
 
 import argparse
 import inspect
+from collections import OrderedDict
 from pathlib import Path
-from typing import Optional, Sequence, Type
+from typing import Optional, Sequence
 
 import torch
 from torch import nn
@@ -22,6 +23,15 @@ except ImportError as exc:  # pragma: no cover - import guard
         "https://github.com/llvm/torch-mlir for installation instructions."
     ) from exc
 
+try:
+    import torchvision.models as tv_models
+except ImportError as exc:  # pragma: no cover - import guard
+    raise SystemExit(
+        "torchvision must be installed to run this script. See "
+        "https://pytorch.org/vision/stable/index.html for installation "
+        "instructions."
+    ) from exc
+
 
 try:
     _COMPILE_SUPPORTS_EXPORTED_NAME = (
@@ -32,189 +42,73 @@ except (ValueError, TypeError):  # pragma: no cover - defensive
 
 
 # ---------------------------------------------------------------------------
-# ResNet-18 implementation
+# Argument parsing helpers
 # ---------------------------------------------------------------------------
 
 
-def _conv3x3(in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
-    """3x3 convolution with padding."""
+def positive_int(value: str) -> int:
+    """argparse helper that accepts positive integer values."""
 
-    return nn.Conv2d(
-        in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False
-    )
-
-
-def _conv1x1(in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
-    """1x1 convolution."""
-
-    return nn.Conv2d(
-        in_planes, out_planes, kernel_size=1, stride=stride, padding=0, bias=False
-    )
-
-
-class BasicBlock(nn.Module):
-    """Residual building block used by ResNet-18."""
-
-    expansion: int = 1
-
-    def __init__(
-        self,
-        inplanes: int,
-        planes: int,
-        stride: int = 1,
-        downsample: Optional[nn.Module] = None,
-        norm_layer: Optional[nn.Module] = None,
-    ) -> None:
-        super().__init__()
-        if norm_layer is None:
-            norm_layer = nn.BatchNorm2d
-
-        self.conv1 = _conv3x3(inplanes, planes, stride)
-        self.bn1 = norm_layer(planes)
-        self.relu = nn.ReLU(inplace=True)
-        self.conv2 = _conv3x3(planes, planes)
-        self.bn2 = norm_layer(planes)
-        self.downsample = downsample
-        self.stride = stride
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        identity = x
-
-        out = self.conv1(x)
-        out = self.bn1(out)
-        out = self.relu(out)
-
-        out = self.conv2(out)
-        out = self.bn2(out)
-
-        if self.downsample is not None:
-            identity = self.downsample(x)
-
-        out += identity
-        out = self.relu(out)
-
-        return out
-
-
-class ResNet(nn.Module):
-    """Minimal ResNet backbone matching the ResNet-18 topology."""
-
-    def __init__(
-        self,
-        block: Type[BasicBlock],
-        layers: Sequence[int],
-        num_classes: int = 1000,
-        norm_layer: Optional[nn.Module] = None,
-    ) -> None:
-        super().__init__()
-        if norm_layer is None:
-            norm_layer = nn.BatchNorm2d
-
-        self._norm_layer = norm_layer
-
-        self.inplanes = 64
-        self.conv1 = nn.Conv2d(
-            3, self.inplanes, kernel_size=7, stride=2, padding=3, bias=False
-        )
-        self.bn1 = norm_layer(self.inplanes)
-        self.relu = nn.ReLU(inplace=True)
-        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
-
-        self.layer1 = self._make_layer(block, 64, layers[0])
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-
-        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
-        self.fc = nn.Linear(512 * block.expansion, num_classes)
-
-        self._initialize_weights()
-
-    def _make_layer(
-        self,
-        block: Type[BasicBlock],
-        planes: int,
-        blocks: int,
-        stride: int = 1,
-    ) -> nn.Sequential:
-        norm_layer = self._norm_layer
-        downsample: Optional[nn.Module] = None
-
-        if stride != 1 or self.inplanes != planes * block.expansion:
-            downsample = nn.Sequential(
-                _conv1x1(self.inplanes, planes * block.expansion, stride),
-                norm_layer(planes * block.expansion),
-            )
-
-        layers: list[nn.Module] = []
-        layers.append(block(self.inplanes, planes, stride, downsample, norm_layer))
-        self.inplanes = planes * block.expansion
-        for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes, norm_layer=norm_layer))
-
-        return nn.Sequential(*layers)
-
-    def _initialize_weights(self) -> None:
-        for module in self.modules():
-            if isinstance(module, nn.Conv2d):
-                nn.init.kaiming_normal_(module.weight, mode="fan_out", nonlinearity="relu")
-            elif isinstance(module, (nn.BatchNorm2d, nn.GroupNorm)):
-                nn.init.constant_(module.weight, 1.0)
-                nn.init.constant_(module.bias, 0.0)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        x = self.conv1(x)
-        x = self.bn1(x)
-        x = self.relu(x)
-        x = self.maxpool(x)
-
-        x = self.layer1(x)
-        x = self.layer2(x)
-        x = self.layer3(x)
-        x = self.layer4(x)
-
-        x = self.avgpool(x)
-        x = torch.flatten(x, 1)
-        x = self.fc(x)
-        return x
-
-
-def resnet18(num_classes: int = 1000) -> ResNet:
-    """Constructs a ResNet-18 model instance."""
-
-    return ResNet(BasicBlock, layers=(2, 2, 2, 2), num_classes=num_classes)
-
-
-# ---------------------------------------------------------------------------
-# MLIR generation logic
-# ---------------------------------------------------------------------------
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return ivalue
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--model",
+        type=str,
+        default="resnet18",
+        help=(
+            "Name of the torchvision model to instantiate (default: resnet18)."
+            " Use `python -c \"import torchvision.models as m; print(m.list_models())\"`"
+            " to see the available identifiers."
+        ),
+    )
+    parser.add_argument(
+        "--weights",
+        type=str,
+        default=None,
+        help=(
+            "Optional pretrained weights identifier. Provide either the enum"
+            " member name such as `IMAGENET1K_V1` or a fully qualified"
+            " reference like `ResNet18_Weights.IMAGENET1K_V1`."
+        ),
+    )
+    parser.add_argument(
         "--batch-size",
-        type=int,
+        type=positive_int,
         default=1,
         help="Batch dimension size for the example input tensor (default: 1).",
     )
     parser.add_argument(
+        "--channels",
+        type=positive_int,
+        default=3,
+        help="Channel dimension size for the example input tensor (default: 3).",
+    )
+    parser.add_argument(
         "--height",
-        type=int,
+        type=positive_int,
         default=224,
         help="Input tensor height in pixels (default: 224).",
     )
     parser.add_argument(
         "--width",
-        type=int,
+        type=positive_int,
         default=224,
         help="Input tensor width in pixels (default: 224).",
     )
     parser.add_argument(
         "--num-classes",
-        type=int,
-        default=1000,
-        help="Number of output classes for the classification head (default: 1000).",
+        type=positive_int,
+        default=None,
+        help=(
+            "Override the number of output classes when the model exposes a"
+            " standard `.fc` or `.classifier` head."
+        ),
     )
     parser.add_argument(
         "--exported-name",
@@ -236,8 +130,149 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def build_example_inputs(batch: int, height: int, width: int) -> Sequence[torch.Tensor]:
-    example = torch.randn(batch, 3, height, width, dtype=torch.float32)
+# ---------------------------------------------------------------------------
+# Model instantiation utilities
+# ---------------------------------------------------------------------------
+
+
+def _resolve_weights(model_name: str, weights_name: Optional[str]):
+    """Resolve a weights enum entry from a user-provided identifier."""
+
+    if weights_name is None:
+        return None
+
+    if "." in weights_name:
+        enum_name, member_name = weights_name.split(".", 1)
+        try:
+            enum_cls = getattr(tv_models, enum_name)
+        except AttributeError as exc:  # pragma: no cover - defensive
+            raise SystemExit(
+                f"Unknown torchvision weights enum '{enum_name}'."
+            ) from exc
+        try:
+            return getattr(enum_cls, member_name)
+        except AttributeError as exc:  # pragma: no cover - defensive
+            raise SystemExit(
+                f"Unknown weights member '{weights_name}'."
+            ) from exc
+
+    try:
+        weights_enum = tv_models.get_model_weights(model_name)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise SystemExit(
+            f"Model '{model_name}' does not define pretrained weights in this"
+            " version of torchvision."
+        ) from exc
+
+    candidate_names = [
+        weights_name,
+        weights_name.upper(),
+        weights_name.upper().replace("-", "_"),
+    ]
+    seen: set[str] = set()
+    for candidate in candidate_names:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            return weights_enum[candidate]
+        except KeyError:
+            continue
+
+    available = ", ".join(weight.name for weight in weights_enum)
+    raise SystemExit(
+        f"Unknown weights '{weights_name}' for model '{model_name}'. Available"
+        f" options: {available}"
+    )
+
+
+def _instantiate_model(model_name: str, weights, num_classes: Optional[int]) -> nn.Module:
+    get_model_fn = getattr(tv_models, "get_model", None)
+    model: Optional[nn.Module] = None
+    if callable(get_model_fn):
+        try:
+            model = get_model_fn(model_name, weights=weights)
+        except ValueError:
+            model = None
+    if model is None:
+        try:
+            model_builder = getattr(tv_models, model_name)
+        except AttributeError as exc:  # pragma: no cover - defensive
+            available = []
+            list_models = getattr(tv_models, "list_models", None)
+            if callable(list_models):
+                available = sorted(list_models())
+            hint = (
+                f"Unknown model '{model_name}'."
+                + (f" Available models include: {', '.join(available)}" if available else "")
+            )
+            raise SystemExit(hint) from exc
+        kwargs = {"weights": weights} if weights is not None else {}
+        try:
+            model = model_builder(**kwargs)
+        except TypeError as exc:  # pragma: no cover - defensive
+            if weights is not None:
+                raise SystemExit(
+                    f"Model '{model_name}' does not accept a 'weights' argument in this"
+                    " version of torchvision. Remove --weights or upgrade torchvision."
+                ) from exc
+            raise
+
+    if num_classes is not None:
+        if not _replace_classification_head(model, num_classes):
+            raise SystemExit(
+                f"Model '{model_name}' does not expose a replaceable '.fc' or"
+                " '.classifier' module."
+            )
+    model.eval()
+    return model
+
+
+def _replace_classification_head(module: nn.Module, num_classes: int) -> bool:
+    """Replace a standard classification head with a new linear layer."""
+
+    if hasattr(module, "fc") and isinstance(module.fc, nn.Linear):
+        in_features = module.fc.in_features
+        module.fc = nn.Linear(in_features, num_classes)
+        return True
+
+    if hasattr(module, "classifier"):
+        classifier = getattr(module, "classifier")
+        if isinstance(classifier, nn.Linear):
+            in_features = classifier.in_features
+            module.classifier = nn.Linear(in_features, num_classes)
+            return True
+        if isinstance(classifier, nn.Sequential):
+            named_modules = list(classifier.named_children())
+            for index in range(len(named_modules) - 1, -1, -1):
+                name, child = named_modules[index]
+                if isinstance(child, nn.Linear):
+                    new_linear = nn.Linear(child.in_features, num_classes)
+                    named_modules[index] = (name, new_linear)
+                    module.classifier = nn.Sequential(OrderedDict(named_modules))
+                    return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# MLIR generation logic
+# ---------------------------------------------------------------------------
+
+
+def build_example_inputs(
+    batch: int, channels: int, height: int, width: int
+) -> Sequence[torch.Tensor]:
+    for name, value in (
+        ("batch-size", batch),
+        ("channels", channels),
+        ("height", height),
+        ("width", width),
+    ):
+        if value <= 0:
+            raise ValueError(f"{name} must be a positive integer (got {value}).")
+
+    example = torch.randn((batch, channels, height, width), dtype=torch.float32)
     return (example,)
 
 
@@ -296,10 +331,12 @@ def compile_to_linalg_on_tensors(
 def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parse_args(argv)
 
-    model = resnet18(num_classes=args.num_classes)
-    model.eval()
+    weights = _resolve_weights(args.model, args.weights)
+    model = _instantiate_model(args.model, weights=weights, num_classes=args.num_classes)
 
-    example_inputs = build_example_inputs(args.batch_size, args.height, args.width)
+    example_inputs = build_example_inputs(
+        args.batch_size, args.channels, args.height, args.width
+    )
 
     mlir_text = compile_to_linalg_on_tensors(
         model,


### PR DESCRIPTION
## Summary
- document the set of pre-generated MLIR exports in the README for quick reference
- add MLIR modules exported from ResNet18, ResNet50, MobileNetV3 Small (ImageNet weights), AlexNet, and SqueezeNet to `mlir_outputs/`

## Testing
- python -m compileall scripts/resnet18_to_mlir.py
- python scripts/resnet18_to_mlir.py --output mlir_outputs/resnet18.mlir
- python scripts/resnet18_to_mlir.py --model mobilenet_v3_small --weights IMAGENET1K_V1 --output mlir_outputs/mobilenet_v3_small_imagenet.mlir
- python scripts/resnet18_to_mlir.py --model resnet50 --output mlir_outputs/resnet50.mlir
- python scripts/resnet18_to_mlir.py --model alexnet --output mlir_outputs/alexnet.mlir
- python scripts/resnet18_to_mlir.py --model squeezenet1_1 --output mlir_outputs/squeezenet1_1.mlir

------
https://chatgpt.com/codex/tasks/task_e_68cd272baf548325847f2ddede50987d